### PR TITLE
fix: correções de deploy no servidor do parceiro

### DIFF
--- a/docker-compose.prd.external-db.yml
+++ b/docker-compose.prd.external-db.yml
@@ -128,6 +128,13 @@ services:
     command: ["/bin/sh", "-c", "python cli.py db-ensure-current && if [ \"$(echo ${CRON_ENABLED:-true} | tr '[:upper:]' '[:lower:]')\" != \"true\" ]; then echo 'rpa-scheduler disabled'; sleep infinity; fi; exec /bin/bash /app/scripts/prod/cron_loop.sh"]
     volumes: *app-common-volumes
 
+networks:
+  default:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: ${COMPOSE_NETWORK_SUBNET:-192.168.10.0/24}
+
 volumes:
   siscan-data-artifacts:
     # Diretório auxiliar para artefatos do Playwright.

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -160,6 +160,20 @@ O script percorre 8 fases em sequência. As perguntas interativas e os valores e
 
 ## Fases do script
 
+### Pré-requisito: executar como usuário não-root
+
+O GitHub Actions runner **recusa instalação como root** por segurança — ele executa código vindo do GitHub Actions e, se rodasse como root, qualquer workflow poderia comprometer o servidor inteiro. Com um usuário dedicado, o acesso fica isolado.
+
+Antes de executar o script, crie o usuário e mude para ele:
+
+```bash
+sudo useradd -m -s /bin/bash siscan
+sudo usermod -aG docker siscan
+sudo su - siscan
+```
+
+Todos os passos abaixo devem ser executados como esse usuário. O script falha na Fase 1 com mensagem clara caso seja iniciado como root.
+
 ### Fase 1 — Verificação de pré-requisitos
 
 Verifica se os seguintes componentes estão disponíveis e funcionando:

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -91,7 +91,7 @@ Todos os passos da instalação devem ser executados como esse usuário.
 | Docker Engine | ≥ 28.x (não Docker Desktop) | `docker version` — deve mostrar `Server: Docker Engine` |
 | Docker Compose | ≥ 2.37 | `docker compose version` |
 | git | qualquer versão recente | `git --version` |
-| Conectividade de saída HTTPS | `github.com` e `ghcr.io` porta 443 | `curl -s -o /dev/null -w "%{http_code}" https://ghcr.io` deve retornar `200` ou `301` |
+| Conectividade de saída HTTPS | `github.com` e `ghcr.io` porta 443 | `curl -Iv https://github.com` — handshake TLS deve completar. Falha de handshake indica firewall/proxy bloqueando — ver [Problema 3 no TROUBLESHOOTING.md](TROUBLESHOOTING.md#problema-3--falha-tls-ao-conectar-ao-github-handshake-interrompido) |
 
 ### Servidor de banco de dados (externo)
 

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -67,6 +67,18 @@ flowchart TD
 
 ## Pré-requisitos
 
+### Usuário dedicado
+
+O GitHub Actions runner **não pode ser instalado como root**. Crie e use um usuário dedicado:
+
+```bash
+sudo useradd -m -s /bin/bash siscan
+sudo usermod -aG docker siscan
+sudo su - siscan
+```
+
+Todos os passos da instalação devem ser executados como esse usuário.
+
 ### Servidor de aplicação
 
 | Requisito | Mínimo | Verificação |

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -73,6 +73,7 @@ O GitHub Actions runner **não pode ser instalado como root**. Crie e use um usu
 
 ```bash
 sudo useradd -m -s /bin/bash siscan
+sudo passwd siscan
 sudo usermod -aG docker siscan
 sudo su - siscan
 ```
@@ -168,6 +169,7 @@ Antes de executar o script, crie o usuário e mude para ele:
 
 ```bash
 sudo useradd -m -s /bin/bash siscan
+sudo passwd siscan
 sudo usermod -aG docker siscan
 sudo su - siscan
 ```

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -61,7 +61,7 @@ flowchart TD
 
 **Sobre tráfego de rede e segurança:**
 
-O servidor do parceiro **nunca recebe código-fonte** — apenas a imagem pré-compilada e certificada, produzida e assinada pelo pipeline da Prisma. O único tráfego de **entrada** é o job de deploy enviado pelo GitHub via HTTPS (porta 443); todo o restante é tráfego de **saída** — o runner consulta o GitHub para receber jobs e o Docker baixa a imagem do GHCR. Não é necessário abrir nenhuma porta de entrada no firewall do servidor.
+>  ⚠️  O servidor do parceiro **nunca recebe código-fonte** — apenas a imagem pré-compilada e certificada, produzida e assinada pelo pipeline da Prisma. O único tráfego de **entrada** é o job de deploy enviado pelo GitHub via HTTPS (porta 443); todo o restante é tráfego de **saída** — o runner consulta o GitHub para receber jobs e o Docker baixa a imagem do GHCR. Não é necessário abrir nenhuma porta de entrada no firewall do servidor.
 
 ---
 
@@ -96,7 +96,18 @@ psql -h <DATABASE_HOST> -U siscan_rpa -c "SELECT version();"
 
 ### Token de registro do runner
 
-Obter antes de executar o script: GitHub → repositório `siscan-rpa` → Settings → Actions → Runners → **New self-hosted runner** → copiar o token de registro.
+O token é gerado em:
+**[GitHub → Prisma-Consultoria/siscan-rpa → Settings → Actions → Runners → New self-hosted runner](https://github.com/Prisma-Consultoria/siscan-rpa/settings/actions/runners/new)**
+
+Na tela que abrir, selecione **Linux**. O token aparece embutido na linha de configuração:
+
+```
+./config.sh --url https://github.com/Prisma-Consultoria/siscan-rpa --token <TOKEN>
+```
+
+Copie apenas o valor do `--token`. O script pedirá esse valor interativamente na Fase 6.
+
+>  ⚠️  O token expira em poucos minutos. Gere-o imediatamente antes de executar o script.
 
 ---
 
@@ -110,7 +121,28 @@ cd assistente-siscan-rpa
 bash ./siscan-server-setup.sh
 ```
 
-O script percorre 8 fases em sequência — detalhadas na seção [Fases do script](#fases-do-script) abaixo.
+> **Diretório da stack diferente de `/opt`?** Se o servidor usar outro caminho (ex.: `/app`), passe a variável antes do script:
+> ```bash
+> COMPOSE_DIR=/app/siscan-rpa bash ./siscan-server-setup.sh
+> ```
+
+O script percorre 8 fases em sequência. As perguntas interativas e os valores esperados estão na tabela abaixo — detalhes de cada fase na seção [Fases do script](#fases-do-script).
+
+### Respostas esperadas no menu interativo
+
+| Fase | Pergunta | Valor esperado |
+|---|---|---|
+| 4 | `DATABASE_HOST` | IP ou hostname do PostgreSQL externo (ex.: `192.168.1.10`) |
+| 4 | `DATABASE_PASSWORD` | Senha do banco PostgreSQL |
+| 4 | `HOST_LOG_DIR` | `/app/siscan-rpa/logs` (ou `/opt/siscan-rpa/logs`) |
+| 4 | `HOST_SISCAN_REPORTS_INPUT_DIR` | `/app/siscan-rpa/media/downloads` |
+| 4 | `HOST_REPORTS_OUTPUT_CONSOLIDATED_DIR` | `/app/siscan-rpa/media/reports/mamografia/consolidated` |
+| 4 | `HOST_REPORTS_OUTPUT_CONSOLIDATED_PDFS_DIR` | `/app/siscan-rpa/media/reports/mamografia/consolidated/laudos` |
+| 4 | `HOST_CONFIG_DIR` | `/app/siscan-rpa/config` |
+| 6 | `URL do repositório` | `https://github.com/Prisma-Consultoria/siscan-rpa` |
+| 6 | `Token de registro` | token copiado da tela do GitHub (ver pré-requisitos) |
+
+> `SECRET_KEY` é gerada automaticamente — não pergunta.
 
 ---
 
@@ -159,7 +191,7 @@ Cria o `.env` a partir do `.env.server.sample`. Em seguida, solicita **interativ
 | `HOST_REPORTS_OUTPUT_CONSOLIDATED_PDFS_DIR` | Idem |
 | `HOST_CONFIG_DIR` | Idem |
 
-Caminhos com formato Windows (letra de drive, barras invertidas, UNC) são detectados e o script exibe sugestão de caminho Linux equivalente. A seção [Referência de variáveis](#referência-de-variáveis--env) abaixo documenta todos os valores e seus defaults.
+>  ⚠️  Caminhos com formato Windows (letra de drive, barras invertidas, UNC) são detectados e o script exibe sugestão de caminho Linux equivalente. A seção [Referência de variáveis](#referência-de-variáveis--env) abaixo documenta todos os valores e seus defaults.
 
 ---
 
@@ -176,13 +208,11 @@ Se o runner ainda não estiver instalado (`~/actions-runner/config.sh` ausente):
 1. Detecta a arquitetura do servidor (`x86_64` → `x64`, `aarch64` → `arm64`).
 2. Consulta a versão mais recente do runner via API do GitHub.
 3. Baixa e extrai o tarball oficial.
-4. Solicita interativamente a **URL do repositório** e o **token de registro** (obtido nos pré-requisitos).
+4. Solicita interativamente a **URL do repositório** e o **token de registro** (ver [pré-requisitos](#token-de-registro-do-runner)).
 5. Registra o runner com label `producao-cliente` e nome `<hostname>-siscan-rpa`.
 6. Instala e inicia o runner como **serviço systemd** (via `svc.sh install` + `svc.sh start`).
 
 Se o runner já estiver instalado, verifica se o serviço está ativo e exibe os comandos para iniciar se necessário.
-
-> O token de registro expira em poucos minutos. Tenha-o em mãos imediatamente antes de executar o script.
 
 ---
 
@@ -190,7 +220,7 @@ Se o runner já estiver instalado, verifica se o serviço está ativo e exibe os
 
 Verifica se o usuário atual pertence ao grupo `docker`. Se não pertencer, executa `sudo usermod -aG docker $USER`.
 
-> **Atenção:** a mudança de grupo só tem efeito após logout/login na sessão de terminal. O serviço do runner, por ser gerenciado pelo systemd, já inicia com o grupo correto sem necessidade de reiniciar a sessão.
+>  ⚠️  **Atenção:** a mudança de grupo só tem efeito após logout/login na sessão de terminal. O serviço do runner, por ser gerenciado pelo systemd, já inicia com o grupo correto sem necessidade de reiniciar a sessão.
 
 ---
 
@@ -218,7 +248,7 @@ O `siscan-server-setup.sh` cria o `.env` na fase 4 a partir do `.env.server.samp
 
 Variáveis que raramente precisam de ajuste (pool de conexões, timeouts, workers, scripts externos e variáveis fixas no compose) estão agrupadas em [Configurações avançadas](#configurações-avançadas).
 
-> **Credenciais SISCAN** são configuradas pela interface web após o primeiro start: `http://<IP-DO-SERVIDOR>:<HOST_APP_EXTERNAL_PORT>/admin/siscan-credentials`
+>  ⚠️  **Credenciais SISCAN** são configuradas pela interface web após o primeiro start: `http://<IP-DO-SERVIDOR>:<HOST_APP_EXTERNAL_PORT>/admin/siscan-credentials`
 
 ### Aplicação HTTP
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -225,7 +225,28 @@ HOST_LOG_DIR=C:/siscan-rpa/logs
 
 ## Problemas específicos — Modo Servidor
 
-### Problema 1 — Falha de conexão com o banco de dados externo
+### Problema 1 — Pool de endereços Docker esgotado ao criar rede
+
+Sintoma: deploy falha com:
+```
+failed to create network siscan-rpa_default: Error response from daemon: all predefined address pools have been fully subnetted
+```
+
+O Docker esgotou os blocos de IP disponíveis no pool padrão de redes bridge (172.16.0.0/12). Ocorre quando há muitas redes antigas não utilizadas acumuladas no servidor.
+
+#### Solução
+
+```bash
+# Remover todas as redes Docker sem containers associados
+docker network prune
+```
+
+Confirme com `y`. Em seguida, acione o deploy manualmente:
+**GitHub → repositório `siscan-rpa` → Actions → CD — Deploy Produção → Run workflow**
+
+---
+
+### Problema 2 — Falha de conexão com o banco de dados externo
 
 Sintoma: container `migrate` falha no boot; logs mostram `could not connect to server` ou `connection refused`.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -253,7 +253,66 @@ Sintoma: deploys via GitHub Actions ficam aguardando runner; GitHub mostra runne
 
 ---
 
-### Problema 3 — Permissões Linux nos diretórios `HOST_*`
+### Problema 3 — Falha TLS ao conectar ao GitHub (handshake interrompido)
+
+Sintoma: `curl -Iv https://github.com` conecta na porta 443 mas o handshake TLS falha:
+
+```
+* Connected to github.com (x.x.x.x) port 443
+* TLSv1.3 (OUT), TLS handshake, Client hello (1):
+* OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443
+curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443
+```
+
+A conexão TCP é estabelecida com sucesso, mas o servidor (ou um intermediário) encerra o handshake TLS abruptamente antes de responder.
+
+#### Interpretação técnica
+
+| Diagnóstico | Resultado |
+|---|---|
+| DNS resolve `github.com` | ✔ |
+| TCP conecta na porta 443 | ✔ |
+| Cliente envia `ClientHello` TLS | ✔ |
+| Servidor responde ao handshake | ❌ |
+
+#### Causas mais prováveis (em ordem de probabilidade)
+
+| # | Causa | Indicador |
+|---|---|---|
+| 1 | Firewall ou WAF da rede bloqueando/interceptando TLS para `github.com` | Ocorre apenas de dentro da rede do parceiro |
+| 2 | Proxy corporativo obrigatório não configurado na VM | VM tenta conexão direta, que é bloqueada |
+| 3 | Inspeção SSL por proxy sem certificado confiável instalado | Proxy injeta certificado próprio não reconhecido pelo `ca-certificates` do sistema |
+| 4 | Bloqueio seletivo por IP de `github.com` | Outros domínios HTTPS funcionam normalmente |
+
+#### Diagnóstico
+
+```bash
+# Testar se outros domínios HTTPS funcionam
+curl -Iv https://google.com
+
+# Verificar se há proxy configurado no sistema
+env | grep -i proxy
+
+# Testar com proxy explícito (se houver)
+curl -Iv --proxy http://<PROXY_HOST>:<PORTA> https://github.com
+
+# Verificar política de firewall de saída
+sudo iptables -L OUTPUT -n | grep -E "443|DROP|REJECT"
+```
+
+#### Solução
+
+A resolução depende da infraestrutura do parceiro:
+
+- **Proxy corporativo**: configurar `https_proxy` e `http_proxy` na sessão e/ou no serviço do runner
+- **Firewall bloqueando `github.com`**: solicitar liberação das saídas HTTPS para `github.com` e `ghcr.io` (porta 443)
+- **Inspeção SSL**: instalar o certificado da CA corporativa no sistema (`update-ca-certificates`)
+
+> ⚠️ O runner e o `docker pull` do GHCR precisam de acesso HTTPS de saída para `github.com` e `ghcr.io`. Sem isso, o setup e os deploys automáticos não funcionam.
+
+---
+
+### Problema 4 — Permissões Linux nos diretórios `HOST_*`
 
 Sintoma: `PermissionError` nos logs; container não consegue escrever nos diretórios bind-montados.
 

--- a/siscan-server-setup.sh
+++ b/siscan-server-setup.sh
@@ -198,6 +198,19 @@ printf "  ${GRAY}Label do runner    : %s${NC}\n" "${RUNNER_LABEL}"
 step "FASE 1 — Verificação de pré-requisitos"
 # ════════════════════════════════════════════════════════════════════════════
 
+# Root
+if [ "$(id -u)" -eq 0 ]; then
+    printf "\n${RED}ERRO: Este script não pode ser executado como root.${NC}\n\n"
+    printf "  O GitHub Actions runner recusa instalação com privilégios de superusuário.\n"
+    printf "  Execute como um usuário dedicado, por exemplo:\n\n"
+    printf "    ${CYAN}sudo useradd -m -s /bin/bash siscan${NC}\n"
+    printf "    ${CYAN}sudo usermod -aG docker siscan${NC}\n"
+    printf "    ${CYAN}sudo su - siscan${NC}\n\n"
+    printf "  Em seguida, clone o repositório e execute o script novamente.\n\n"
+    exit 1
+fi
+ok "Usuário não-root: ${CURRENT_USER}"
+
 # Docker
 if ! command -v docker &>/dev/null; then
     fail "Docker não encontrado. Instale com: https://docs.docker.com/engine/install/"

--- a/siscan-server-setup.sh
+++ b/siscan-server-setup.sh
@@ -198,19 +198,6 @@ printf "  ${GRAY}Label do runner    : %s${NC}\n" "${RUNNER_LABEL}"
 step "FASE 1 — Verificação de pré-requisitos"
 # ════════════════════════════════════════════════════════════════════════════
 
-# Root
-if [ "$(id -u)" -eq 0 ]; then
-    printf "\n${RED}ERRO: Este script não pode ser executado como root.${NC}\n\n"
-    printf "  O GitHub Actions runner recusa instalação com privilégios de superusuário.\n"
-    printf "  Execute como um usuário dedicado, por exemplo:\n\n"
-    printf "    ${CYAN}sudo useradd -m -s /bin/bash siscan${NC}\n"
-    printf "    ${CYAN}sudo usermod -aG docker siscan${NC}\n"
-    printf "    ${CYAN}sudo su - siscan${NC}\n\n"
-    printf "  Em seguida, clone o repositório e execute o script novamente.\n\n"
-    exit 1
-fi
-ok "Usuário não-root: ${CURRENT_USER}"
-
 # Docker
 if ! command -v docker &>/dev/null; then
     fail "Docker não encontrado. Instale com: https://docs.docker.com/engine/install/"
@@ -262,7 +249,38 @@ command -v sudo &>/dev/null || fail "sudo não encontrado. Este script precisa d
 ok "sudo disponível"
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 2 — Estrutura de diretórios da stack"
+step "FASE 2 — Usuário dedicado para o runner"
+# ════════════════════════════════════════════════════════════════════════════
+
+if [ "$(id -u)" -eq 0 ]; then
+    printf "  ${GRAY}O GitHub Actions runner recusa execução como root.${NC}\n"
+    printf "  ${GRAY}Criando usuário dedicado 'siscan' e re-executando o script como ele.${NC}\n\n"
+
+    if id siscan &>/dev/null; then
+        ok "Usuário 'siscan' já existe"
+    else
+        useradd -m -s /bin/bash siscan || fail "Não foi possível criar o usuário 'siscan'"
+        ok "Usuário 'siscan' criado"
+        printf "\n  ${CYAN}Defina a senha do usuário 'siscan':${NC}\n"
+        passwd siscan || fail "Não foi possível definir a senha do usuário 'siscan'"
+    fi
+
+    if id -nG siscan | grep -qw docker; then
+        ok "Usuário 'siscan' já está no grupo 'docker'"
+    else
+        usermod -aG docker siscan || fail "Não foi possível adicionar 'siscan' ao grupo 'docker'"
+        ok "Usuário 'siscan' adicionado ao grupo 'docker'"
+    fi
+
+    info "Re-executando o script como usuário 'siscan'..."
+    SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+    exec sudo -u siscan COMPOSE_DIR="${COMPOSE_DIR}" RUNNER_DIR="${RUNNER_DIR}" RUNNER_LABEL="${RUNNER_LABEL}" bash "${SCRIPT_PATH}"
+else
+    ok "Usuário não-root: ${CURRENT_USER}"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+step "FASE 3 — Estrutura de diretórios da stack"
 # ════════════════════════════════════════════════════════════════════════════
 
 if [ -d "${COMPOSE_DIR}" ]; then
@@ -284,7 +302,7 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 3 — Arquivos da stack"
+step "FASE 4 — Arquivos da stack"
 # ════════════════════════════════════════════════════════════════════════════
 
 # docker-compose.prd.external-db.yml
@@ -326,7 +344,7 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 4 — Configuração do .env"
+step "FASE 5 — Configuração do .env"
 # ════════════════════════════════════════════════════════════════════════════
 
 # Criar .env a partir do sample se não existir
@@ -470,13 +488,13 @@ for var in "${HOST_PATH_VARS[@]}"; do
 done
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 5 — Criação dos diretórios HOST_*"
+step "FASE 6 — Criação dos diretórios HOST_*"
 # ════════════════════════════════════════════════════════════════════════════
 
 ensure_host_paths "${ENV_FILE}"
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 6 — GitHub Actions Runner"
+step "FASE 7 — GitHub Actions Runner"
 # ════════════════════════════════════════════════════════════════════════════
 
 RUNNER_ALREADY_INSTALLED=false
@@ -579,7 +597,7 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 7 — Permissões Docker"
+step "FASE 8 — Permissões Docker"
 # ════════════════════════════════════════════════════════════════════════════
 
 if id -nG "${CURRENT_USER}" 2>/dev/null | grep -qw docker; then
@@ -595,7 +613,7 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 8 — Resumo e próximos passos"
+step "FASE 9 — Resumo e próximos passos"
 # ════════════════════════════════════════════════════════════════════════════
 
 printf "  ${GREEN}Setup concluído!${NC}\n\n"

--- a/siscan-server-setup.sh
+++ b/siscan-server-setup.sh
@@ -566,12 +566,13 @@ else
     ok "Runner registrado: $(hostname)-siscan-rpa [${RUNNER_LABEL}]"
 
     # Instalar e iniciar como serviço systemd
+    # sudo não preserva o diretório de trabalho — passar via bash -c para garantir
     info "Instalando runner como serviço systemd (usuário: ${CURRENT_USER})..."
-    if ! (cd "${RUNNER_DIR}" && sudo ./svc.sh install "${CURRENT_USER}"); then
+    if ! sudo bash -c "cd '${RUNNER_DIR}' && ./svc.sh install '${CURRENT_USER}'"; then
         fail "Falha ao instalar o serviço systemd do runner."
     fi
 
-    if ! (cd "${RUNNER_DIR}" && sudo ./svc.sh start); then
+    if ! sudo bash -c "cd '${RUNNER_DIR}' && ./svc.sh start"; then
         fail "Falha ao iniciar o serviço do runner."
     fi
     ok "Serviço do runner instalado e iniciado"


### PR DESCRIPTION
## Resumo

Conjunto de correções identificadas durante o deploy real no servidor do parceiro.

## Mudanças

- **`docker-compose.prd.external-db.yml`**: define sub-rede explícita `192.168.10.0/24` via `COMPOSE_NETWORK_SUBNET` para evitar bloqueio da faixa `172.x.x.x` em ambientes corporativos
- **`siscan-server-setup.sh`**: cria usuário dedicado `siscan` automaticamente na Fase 2 (runner recusa root); preserva diretório ao instalar `svc.sh` com sudo
- **`docs/DEPLOY_SERVER.md`**: orienta geração do token, override do `COMPOSE_DIR`, pré-requisito de usuário não-root
- **`docs/TROUBLESHOOTING.md`**: documenta falha TLS no handshake com `github.com` e pool de endereços Docker esgotado

## Test plan

- [x] Testado em deploy real no servidor do parceiro

🤖 Generated with [Claude Code](https://claude.com/claude-code)