### PR TITLE
fix(compose): remover subnet fixa do docker-compose.prd.external-db.yml

### DIFF
--- a/docker-compose.prd.external-db.yml
+++ b/docker-compose.prd.external-db.yml
@@ -128,13 +128,6 @@ services:
     command: ["/bin/sh", "-c", "python cli.py db-ensure-current && if [ \"$(echo ${CRON_ENABLED:-true} | tr '[:upper:]' '[:lower:]')\" != \"true\" ]; then echo 'rpa-scheduler disabled'; sleep infinity; fi; exec /bin/bash /app/scripts/prod/cron_loop.sh"]
     volumes: *app-common-volumes
 
-networks:
-  default:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: ${COMPOSE_NETWORK_SUBNET:-192.168.10.0/24}
-
 volumes:
   siscan-data-artifacts:
     # Diretório auxiliar para artefatos do Playwright.


### PR DESCRIPTION
## Resumo

- Remove bloco `networks.default.ipam` com subnet fixa `192.168.10.0/24` do compose de produção
- A subnet estática causava falha `all predefined address pools have been fully subnetted` em servidores com pool Docker restrito
- Sem subnet explícita, o Docker aloca automaticamente o endereço disponível no pool do daemon

## Contexto

O servidor do parceiro tem `daemon.json` com pool restrito (`192.168.4.0/24, size: 24`), o que limita a criação de redes. A subnet fixa no compose não é necessária e estava causando conflito.

## Plano de teste

- [ ] Deploy no servidor do parceiro sem erro de subnet
- [ ] Containers sobem e comunicam normalmente
- [ ] `docker network ls` mostra a rede siscan-rpa com IP alocado automaticamente