### PR TITLE
feat(scripts): persistir DIR_SISCAN_ASSISTENTE para runner e compose

### DIFF
--- a/docs/DEPLOY_HOST.md
+++ b/docs/DEPLOY_HOST.md
@@ -62,6 +62,8 @@ cd assistente-siscan-rpa
 bash ./siscan-assistente.sh
 ```
 
+> ℹ️  Na primeira execução (Linux), o script define automaticamente a variável `DIR_SISCAN_ASSISTENTE` apontando para o diretório onde o repositório foi clonado. Ela é persistida no `.env` do compose e em `/etc/environment`, sobrevivendo a reinicializações.
+
 Para resetar as credenciais (ex.: token expirou):
 
 ```powershell

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -126,7 +126,7 @@ bash ./siscan-server-setup.sh
 > COMPOSE_DIR=/app/siscan-rpa bash ./siscan-server-setup.sh
 > ```
 
-O script percorre 8 fases em sequência. As perguntas interativas e os valores esperados estão na tabela abaixo — detalhes de cada fase na seção [Fases do script](#fases-do-script).
+O script percorre 9 fases em sequência. As perguntas interativas e os valores esperados estão na tabela abaixo — detalhes de cada fase na seção [Fases do script](#fases-do-script).
 
 ### Respostas esperadas no menu interativo
 
@@ -182,6 +182,7 @@ O relatório cobre:
 
 | Verificação | O que é checado |
 |---|---|
+| `DIR_SISCAN_ASSISTENTE` | Verifica se a variável está definida no ambiente do runner (lida do `~/actions-runner/.env`) e se o diretório existe |
 | Usuário e permissões | `whoami`, `id`, permissões do `COMPOSE_DIR`, `.env` e compose file |
 | Sistema operacional | `lsb_release`, CPUs, memória, disco |
 | Docker | Versão do Engine e Compose, `daemon.json`, redes existentes e sub-redes |
@@ -259,9 +260,32 @@ Verifica se o usuário atual pertence ao grupo `docker`. Se não pertencer, exec
 
 ---
 
-### Fase 8 — Resumo e próximos passos
+### Fase 8 — Persistir `DIR_SISCAN_ASSISTENTE`
 
-Exibe um resumo do que foi configurado (diretórios, compose, `.env`, runner, label) e os próximos passos:
+O script resolve automaticamente o diretório raiz do assistente (onde o repositório foi clonado) e persiste a variável `DIR_SISCAN_ASSISTENTE` em **três locais**:
+
+| Local | Para quem serve | Sobrevive a reboot? |
+|---|---|---|
+| `${COMPOSE_DIR}/.env` | `docker compose` — interpola a variável nos compose files | Sim |
+| `${RUNNER_DIR}/.env` | Jobs do GitHub Actions (diagnóstico e deploy) | Sim |
+| `/etc/environment` | Sessões interativas de qualquer usuário (root, siscan, etc.) | Sim |
+
+Cada parceiro pode clonar o repositório em qualquer caminho (ex.: `/app/assistente-siscan-rpa`, `/opt/siscan-rpa`, `/home/siscan/assistente`). O script detecta o caminho automaticamente e o propaga para os três destinos sem intervenção manual.
+
+>  ⚠️  **Por que o `.env` do runner?** O GitHub Actions runner roda como serviço systemd e **não carrega** `~/.bashrc` nem `/etc/environment`. O único mecanismo para injetar variáveis de ambiente nos jobs é o arquivo `.env` dentro do diretório do runner (`~/actions-runner/.env`). Sem essa entrada, os jobs de diagnóstico e deploy não conseguem localizar o diretório da stack.
+
+Se o runner já estiver instalado mas a variável não estiver configurada (ex.: servidor configurado antes desta atualização), execute manualmente:
+
+```bash
+echo 'DIR_SISCAN_ASSISTENTE=/caminho/do/assistente' >> ~/actions-runner/.env
+sudo ~/actions-runner/svc.sh stop && sudo ~/actions-runner/svc.sh start
+```
+
+---
+
+### Fase 9 — Resumo e próximos passos
+
+Exibe um resumo do que foi configurado (diretórios, compose, `.env`, runner, label, `DIR_SISCAN_ASSISTENTE`) e os próximos passos:
 
 1. Revisar o `.env` em `/opt/siscan-rpa/.env`.
 2. Confirmar que o runner aparece como **Idle** em GitHub → Settings → Actions → Runners.
@@ -284,6 +308,14 @@ O `siscan-server-setup.sh` cria o `.env` na fase 4 a partir do `.env.server.samp
 Variáveis que raramente precisam de ajuste (pool de conexões, timeouts, workers, scripts externos e variáveis fixas no compose) estão agrupadas em [Configurações avançadas](#configurações-avançadas).
 
 >  ⚠️  **Credenciais SISCAN** são configuradas pela interface web após o primeiro start: `http://<IP-DO-SERVIDOR>:<HOST_APP_EXTERNAL_PORT>/admin/siscan-credentials`
+
+### Variável de ambiente do assistente
+
+| Variável | Definida por | Onde é persistida | Obrigatória? | O que faz / Impacto |
+|---|---|---|---|---|
+| `DIR_SISCAN_ASSISTENTE` | `siscan-server-setup.sh` (Fase 8) | `.env` do compose, `.env` do runner, `/etc/environment` | **Sim** | Caminho raiz do repositório `assistente-siscan-rpa` no servidor. Usada pelo workflow de CD (diagnóstico e deploy) para localizar o compose file e o `.env`. Sem ela, o deploy falha. |
+
+>  ℹ️  O valor é resolvido automaticamente pelo `siscan-server-setup.sh` a partir do diretório onde o script foi executado — não precisa ser preenchido manualmente.
 
 ### Aplicação HTTP
 

--- a/siscan-assistente.sh
+++ b/siscan-assistente.sh
@@ -34,6 +34,40 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ---------------------------------------------------------------------------
+# DIR_SISCAN_ASSISTENTE — raiz do Assistente SIScan RPA
+# Exportada para sessão atual e persistida no ~/.bashrc do usuário para
+# sobreviver a reinicializações do sistema.
+# ---------------------------------------------------------------------------
+export DIR_SISCAN_ASSISTENTE="${SCRIPT_DIR}"
+
+_persist_dir_siscan_assistente() {
+    local value="${SCRIPT_DIR}"
+    local marker="DIR_SISCAN_ASSISTENTE="
+
+    # 1) Persistir no .env do docker compose (sem export)
+    local env_file="${SCRIPT_DIR}/.env"
+    if [ -f "${env_file}" ]; then
+        if grep -q "^${marker}" "${env_file}" 2>/dev/null; then
+            sed -i "s|^${marker}.*|${marker}${value}|" "${env_file}"
+        else
+            printf '\n# Diretório raiz do Assistente SIScan RPA\n%s%s\n' \
+                "${marker}" "${value}" >> "${env_file}"
+        fi
+    fi
+
+    # 2) Persistir no /etc/environment (disponível para todos os usuários)
+    local etc_env="/etc/environment"
+    if [ -w "${etc_env}" ] 2>/dev/null || command -v sudo &>/dev/null; then
+        if grep -q "^${marker}" "${etc_env}" 2>/dev/null; then
+            sudo sed -i "s|^${marker}.*|${marker}\"${value}\"|" "${etc_env}" 2>/dev/null || true
+        else
+            echo "${marker}\"${value}\"" | sudo tee -a "${etc_env}" >/dev/null 2>/dev/null || true
+        fi
+    fi
+}
+_persist_dir_siscan_assistente
+
+# ---------------------------------------------------------------------------
 # Cores ANSI
 # ---------------------------------------------------------------------------
 RED='\033[0;31m'

--- a/siscan-server-setup.sh
+++ b/siscan-server-setup.sh
@@ -47,6 +47,54 @@ RUNNER_LABEL="${RUNNER_LABEL:-producao-cliente}"
 CURRENT_USER="$(whoami)"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# DIR_SISCAN_ASSISTENTE — raiz do Assistente SIScan RPA
+# Exportada para sessão atual e persistida em três locais:
+#   1) .env do docker compose  — para docker compose interpolar
+#   2) .env do actions-runner   — para jobs do GitHub Actions enxergarem
+#   3) /etc/environment         — para sessões interativas de qualquer usuário
+export DIR_SISCAN_ASSISTENTE="${SCRIPT_DIR}"
+
+_persist_dir_siscan_assistente() {
+    local value="${SCRIPT_DIR}"
+    local marker="DIR_SISCAN_ASSISTENTE="
+
+    # Função auxiliar: grava marker=value num arquivo, atualizando se já existe
+    _upsert_env_line() {
+        local file="${1}" line="${2}"
+        if grep -q "^${marker}" "${file}" 2>/dev/null; then
+            sed -i "s|^${marker}.*|${line}|" "${file}"
+        else
+            printf '\n# Diretório raiz do Assistente SIScan RPA\n%s\n' \
+                "${line}" >> "${file}"
+        fi
+    }
+
+    # 1) .env do docker compose (sem aspas — formato KEY=value)
+    local compose_env="${COMPOSE_DIR}/.env"
+    if [ -f "${compose_env}" ]; then
+        _upsert_env_line "${compose_env}" "${marker}${value}"
+    fi
+
+    # 2) .env do GitHub Actions runner (sem aspas — formato KEY=value)
+    local runner_env="${RUNNER_DIR}/.env"
+    if [ -d "${RUNNER_DIR}" ]; then
+        touch "${runner_env}" 2>/dev/null || true
+        _upsert_env_line "${runner_env}" "${marker}${value}"
+    fi
+
+    # 3) /etc/environment (com aspas — formato KEY="value")
+    local etc_env="/etc/environment"
+    if [ -w "${etc_env}" ] 2>/dev/null || command -v sudo &>/dev/null; then
+        if grep -q "^${marker}" "${etc_env}" 2>/dev/null; then
+            sudo sed -i "s|^${marker}.*|${marker}\"${value}\"|" "${etc_env}" 2>/dev/null || true
+        else
+            echo "${marker}\"${value}\"" | sudo tee -a "${etc_env}" >/dev/null 2>/dev/null || true
+        fi
+    fi
+}
+# Nota: _persist_dir_siscan_assistente é chamada na FASE 8.5, após o runner
+# estar instalado, para que o .env do runner já exista.
+
 COMPOSE_FILE="docker-compose.prd.external-db.yml"
 ENV_FILE="${COMPOSE_DIR}/.env"
 
@@ -618,17 +666,32 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
+step "FASE 8.5 — Persistir DIR_SISCAN_ASSISTENTE"
+# ════════════════════════════════════════════════════════════════════════════
+
+info "DIR_SISCAN_ASSISTENTE=${DIR_SISCAN_ASSISTENTE}"
+_persist_dir_siscan_assistente
+ok ".env do compose: ${COMPOSE_DIR}/.env"
+if [ -d "${RUNNER_DIR}" ]; then
+    ok ".env do runner:  ${RUNNER_DIR}/.env"
+else
+    warn "Runner não encontrado em ${RUNNER_DIR} — configure manualmente: echo 'DIR_SISCAN_ASSISTENTE=${DIR_SISCAN_ASSISTENTE}' >> <RUNNER_DIR>/.env"
+fi
+ok "/etc/environment"
+
+# ════════════════════════════════════════════════════════════════════════════
 step "FASE 9 — Resumo e próximos passos"
 # ════════════════════════════════════════════════════════════════════════════
 
 printf "  ${GREEN}Setup concluído!${NC}\n\n"
 
 printf "  ${WHITE}O que foi configurado:${NC}\n"
-ok "Stack:   ${COMPOSE_DIR}"
-ok "Compose: ${COMPOSE_DIR}/${COMPOSE_FILE}"
-ok "Env:     ${ENV_FILE}"
-ok "Runner:  ${RUNNER_DIR}"
-ok "Label:   ${RUNNER_LABEL}"
+ok "Stack:      ${COMPOSE_DIR}"
+ok "Compose:    ${COMPOSE_DIR}/${COMPOSE_FILE}"
+ok "Env:        ${ENV_FILE}"
+ok "Runner:     ${RUNNER_DIR}"
+ok "Label:      ${RUNNER_LABEL}"
+ok "Assistente: DIR_SISCAN_ASSISTENTE=${DIR_SISCAN_ASSISTENTE}"
 
 printf "\n  ${WHITE}Próximos passos:${NC}\n\n"
 


### PR DESCRIPTION
## Summary

- **`siscan-server-setup.sh`**: exporta e persiste `DIR_SISCAN_ASSISTENTE` (diretório raiz do assistente) em 3 locais — `.env` do compose, `.env` do runner (`~/actions-runner/.env`) e `/etc/environment` — garantindo que a variável sobreviva a reinicializações e esteja disponível para o workflow de CD (diagnóstico e deploy)
- **`siscan-assistente.sh`** (host): exporta e persiste a variável no `.env` do compose e `/etc/environment`
- **Documentação**: nova Fase 8 no `DEPLOY_SERVER.md` com tabela dos locais de persistência, instrução manual para servidores já configurados, e referência da variável

## Motivação

O workflow de CD (`cd_imagem_certificada_selfhosted.yml`) depende de `DIR_SISCAN_ASSISTENTE` para localizar o diretório da stack no servidor de cada parceiro. Como o runner do GitHub Actions roda via systemd, ele **não carrega** `~/.bashrc` nem `/etc/environment` — a única forma de injetar variáveis nos jobs é via `~/actions-runner/.env`. Cada parceiro pode clonar o assistente em qualquer caminho, e o script resolve isso automaticamente a partir de `SCRIPT_DIR`.

## Arquivos alterados

| Arquivo | O que muda |
|---|---|
| `siscan-server-setup.sh` | Nova FASE 8.5, função `_persist_dir_siscan_assistente` com upsert em 3 arquivos, resumo atualizado |
| `siscan-assistente.sh` | `export DIR_SISCAN_ASSISTENTE`, persistência no `.env` e `/etc/environment` |
| `docs/DEPLOY_SERVER.md` | Nova seção Fase 8, tabela de diagnóstico, referência de variável, contagem de fases 8→9 |
| `docs/DEPLOY_HOST.md` | Nota sobre `DIR_SISCAN_ASSISTENTE` na execução Linux |

## Test plan

- [ ] Executar `siscan-server-setup.sh` em servidor limpo — verificar que `DIR_SISCAN_ASSISTENTE` aparece em `${COMPOSE_DIR}/.env`, `${RUNNER_DIR}/.env` e `/etc/environment`
- [ ] Re-executar o script do mesmo diretório — verificar que os valores são atualizados (não duplicados)
- [ ] Re-executar de outro diretório — verificar que o valor é atualizado para o novo caminho
- [ ] Reiniciar o serviço do runner e executar o workflow de CD — verificar que o job de diagnóstico exibe `DIR_SISCAN_ASSISTENTE` corretamente
- [ ] Executar `siscan-assistente.sh` em modo host — verificar que a variável aparece no `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)