### PR TITLE
feat(scripts): persistir DIR_SISCAN_ASSISTENTE e remover COMPOSE_DIR

### DIFF
--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -121,10 +121,7 @@ cd assistente-siscan-rpa
 bash ./siscan-server-setup.sh
 ```
 
-> **Diretório da stack diferente de `/opt`?** Se o servidor usar outro caminho (ex.: `/app`), passe a variável antes do script:
-> ```bash
-> COMPOSE_DIR=/app/siscan-rpa bash ./siscan-server-setup.sh
-> ```
+> **O diretório da stack é o próprio diretório onde o repositório foi clonado.** Clone no local desejado (ex.: `/app/assistente-siscan-rpa`, `/opt/siscan-rpa`) — o `.env`, o compose file e os configs ficarão todos lá.
 
 O script percorre 9 fases em sequência. As perguntas interativas e os valores esperados estão na tabela abaixo — detalhes de cada fase na seção [Fases do script](#fases-do-script).
 
@@ -164,7 +161,7 @@ Verifica se os seguintes componentes estão disponíveis e funcionando:
 - **Docker Engine**: checa `docker info` (daemon rodando, usuário com acesso ao socket). Se falhar, o script diagnostica a causa — serviço parado, usuário fora do grupo `docker` ou socket ausente — e exibe o comando correto para resolver.
 - **Docker Compose v2** (plugin): checa `docker compose version`.
 - **curl**: necessário para baixar o runner.
-- **sudo**: necessário para criar o `COMPOSE_DIR` e instalar o runner como serviço systemd.
+- **sudo**: necessário para instalar o runner como serviço systemd.
 
 O script **não prossegue** se algum desses itens estiver ausente.
 
@@ -183,7 +180,7 @@ O relatório cobre:
 | Verificação | O que é checado |
 |---|---|
 | `DIR_SISCAN_ASSISTENTE` | Verifica se a variável está definida no ambiente do runner (lida do `~/actions-runner/.env`) e se o diretório existe |
-| Usuário e permissões | `whoami`, `id`, permissões do `COMPOSE_DIR`, `.env` e compose file |
+| Usuário e permissões | `whoami`, `id`, permissões do diretório do assistente, `.env` e compose file |
 | Sistema operacional | `lsb_release`, CPUs, memória, disco |
 | Docker | Versão do Engine e Compose, `daemon.json`, redes existentes e sub-redes |
 | Criação de rede | Testa `docker network create` manualmente para confirmar se o daemon consegue criar redes |
@@ -197,18 +194,13 @@ O relatório fica disponível por **7 dias** após cada execução. Use-o para d
 
 ---
 
-### Fase 2 — Estrutura de diretórios da stack
+### Fase 3 — Verificar arquivos da stack
 
-Cria o diretório principal da stack (`/opt/siscan-rpa` por padrão, sobrescrevível com `COMPOSE_DIR`) via `sudo mkdir -p` se ainda não existir. Em seguida, transfere a propriedade do diretório para o usuário atual (`chown`).
+Verifica que os arquivos necessários estão presentes no diretório do clone:
 
----
-
-### Fase 3 — Arquivos da stack
-
-Copia para `/opt/siscan-rpa/`:
-
-- `docker-compose.prd.external-db.yml` — arquivo de orquestração dos containers `app` e `rpa-scheduler`. Se não estiver no diretório do script, o processo é interrompido com instruções.
-- `config/` — diretório de configurações da aplicação. Se o diretório existir no script, é copiado; caso contrário, é criado vazio com aviso para incluir o `excel_columns_mapping.json` antes de subir a stack.
+- **Permissões** — ajusta o dono do diretório para o usuário atual se necessário.
+- **`docker-compose.prd.external-db.yml`** — deve existir no repositório clonado. Se ausente, o script falha com instruções para verificar o clone.
+- **`config/`** — verifica se o diretório existe e se contém `excel_columns_mapping.json`. Se ausente, cria vazio com aviso.
 
 ---
 
@@ -266,7 +258,7 @@ O script resolve automaticamente o diretório raiz do assistente (onde o reposit
 
 | Local | Para quem serve | Sobrevive a reboot? |
 |---|---|---|
-| `${COMPOSE_DIR}/.env` | `docker compose` — interpola a variável nos compose files | Sim |
+| `.env` (no diretório do assistente) | `docker compose` — interpola a variável nos compose files | Sim |
 | `${RUNNER_DIR}/.env` | Jobs do GitHub Actions (diagnóstico e deploy) | Sim |
 | `/etc/environment` | Sessões interativas de qualquer usuário (root, siscan, etc.) | Sim |
 
@@ -287,12 +279,12 @@ sudo ~/actions-runner/svc.sh stop && sudo ~/actions-runner/svc.sh start
 
 Exibe um resumo do que foi configurado (diretórios, compose, `.env`, runner, label, `DIR_SISCAN_ASSISTENTE`) e os próximos passos:
 
-1. Revisar o `.env` em `/opt/siscan-rpa/.env`.
+1. Revisar o `.env` no diretório do assistente (ex.: `/app/assistente-siscan-rpa/.env`).
 2. Confirmar que o runner aparece como **Idle** em GitHub → Settings → Actions → Runners.
 3. Verificar o serviço: `sudo ~/actions-runner/svc.sh status`.
 4. O próximo merge para `main` acionará o deploy automaticamente; para acionar manualmente: Actions → CD — Deploy Produção → Run workflow.
 5. Acompanhar logs do runner: `journalctl -u actions.runner.*.service -f`.
-6. Após o primeiro deploy, acompanhar logs da stack: `docker compose -f /opt/siscan-rpa/docker-compose.prd.external-db.yml logs -f`.
+6. Após o primeiro deploy, acompanhar logs da stack: `cd <DIR_SISCAN_ASSISTENTE> && docker compose -f docker-compose.prd.external-db.yml logs -f`.
 
 ---
 

--- a/siscan-server-setup.sh
+++ b/siscan-server-setup.sh
@@ -10,7 +10,6 @@
 #   bash ./siscan-server-setup.sh
 #
 # Variáveis de ambiente opcionais:
-#   COMPOSE_DIR    Diretório da stack no servidor (padrão: /opt/siscan-rpa)
 #   RUNNER_DIR     Diretório de instalação do runner (padrão: ~/actions-runner)
 #   RUNNER_LABEL   Label registrada no runner (padrão: producao-cliente)
 #
@@ -18,7 +17,7 @@
 #   - Linux (Ubuntu 22.04+ recomendado)
 #   - Docker Engine >= 24 e Docker Compose >= 2 (plugin)
 #   - curl
-#   - sudo disponível (para criar /opt/siscan-rpa e instalar o runner como serviço)
+#   - sudo disponível (para instalar o runner como serviço)
 #
 # Referência: docs/DEPLOY_AUTOMATICO.md — Opção 1.A Self-hosted Runner
 # -------------------------------------------
@@ -41,14 +40,15 @@ NC='\033[0m'
 # ────────────────────────────────────────────────────────────────────────────
 # Configuração (sobrescrevível via variáveis de ambiente)
 # ────────────────────────────────────────────────────────────────────────────
-COMPOSE_DIR="${COMPOSE_DIR:-/opt/siscan-rpa}"
 RUNNER_DIR="${RUNNER_DIR:-${HOME}/actions-runner}"
 RUNNER_LABEL="${RUNNER_LABEL:-producao-cliente}"
 CURRENT_USER="$(whoami)"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# DIR_SISCAN_ASSISTENTE — raiz do Assistente SIScan RPA
-# Exportada para sessão atual e persistida em três locais:
+# DIR_SISCAN_ASSISTENTE — diretório raiz do assistente (onde o repo foi clonado).
+# O .env, o compose file e o config/ ficam todos aqui — é o diretório que o
+# workflow de CD usa para localizar tudo.
+# Persistida em três locais:
 #   1) .env do docker compose  — para docker compose interpolar
 #   2) .env do actions-runner   — para jobs do GitHub Actions enxergarem
 #   3) /etc/environment         — para sessões interativas de qualquer usuário
@@ -70,7 +70,7 @@ _persist_dir_siscan_assistente() {
     }
 
     # 1) .env do docker compose (sem aspas — formato KEY=value)
-    local compose_env="${COMPOSE_DIR}/.env"
+    local compose_env="${SCRIPT_DIR}/.env"
     if [ -f "${compose_env}" ]; then
         _upsert_env_line "${compose_env}" "${marker}${value}"
     fi
@@ -96,7 +96,7 @@ _persist_dir_siscan_assistente() {
 # estar instalado, para que o .env do runner já exista.
 
 COMPOSE_FILE="docker-compose.prd.external-db.yml"
-ENV_FILE="${COMPOSE_DIR}/.env"
+ENV_FILE="${SCRIPT_DIR}/.env"
 
 # ────────────────────────────────────────────────────────────────────────────
 # Helpers de output
@@ -237,7 +237,7 @@ printf "${WHITE}║  Opção 1.A — Self-hosted Runner + Docker Compose   ║${
 printf "${WHITE}╚════════════════════════════════════════════════════╝${NC}\n"
 printf "\n"
 printf "  ${GRAY}Referência: docs/DEPLOY_AUTOMATICO.md — Opção 1.A${NC}\n"
-printf "  ${GRAY}Diretório da stack : %s${NC}\n" "${COMPOSE_DIR}"
+printf "  ${GRAY}Diretório da stack : %s${NC}\n" "${SCRIPT_DIR}"
 printf "  ${GRAY}Diretório do runner: %s${NC}\n" "${RUNNER_DIR}"
 printf "  ${GRAY}Usuário atual      : %s${NC}\n" "${CURRENT_USER}"
 printf "  ${GRAY}Label do runner    : %s${NC}\n" "${RUNNER_LABEL}"
@@ -293,7 +293,7 @@ command -v curl &>/dev/null || fail "curl não encontrado. Instale com: sudo apt
 ok "curl $(curl --version 2>/dev/null | head -1 | awk '{print $2}')"
 
 # sudo
-command -v sudo &>/dev/null || fail "sudo não encontrado. Este script precisa de sudo para criar ${COMPOSE_DIR} e instalar o runner como serviço systemd."
+command -v sudo &>/dev/null || fail "sudo não encontrado. Este script precisa de sudo para instalar o runner como serviço systemd."
 ok "sudo disponível"
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -327,56 +327,40 @@ if [ "$(id -u)" -eq 0 ]; then
 
     info "Re-executando o script como usuário 'siscan'..."
     SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
-    exec sudo -u siscan COMPOSE_DIR="${COMPOSE_DIR}" RUNNER_DIR="${RUNNER_DIR}" RUNNER_LABEL="${RUNNER_LABEL}" bash "${SCRIPT_PATH}"
+    exec sudo -u siscan RUNNER_DIR="${RUNNER_DIR}" RUNNER_LABEL="${RUNNER_LABEL}" bash "${SCRIPT_PATH}"
 else
     ok "Usuário não-root: ${CURRENT_USER}"
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 3 — Estrutura de diretórios da stack"
+step "FASE 3 — Verificar arquivos da stack"
 # ════════════════════════════════════════════════════════════════════════════
 
-if [ -d "${COMPOSE_DIR}" ]; then
-    ok "${COMPOSE_DIR} já existe"
-else
-    info "Criando ${COMPOSE_DIR}..."
-    sudo mkdir -p "${COMPOSE_DIR}" || fail "Não foi possível criar ${COMPOSE_DIR}. Verifique permissões sudo."
-    ok "${COMPOSE_DIR} criado"
-fi
-
-COMPOSE_DIR_OWNER=$(stat -c '%U' "${COMPOSE_DIR}" 2>/dev/null || echo "")
-if [ "${COMPOSE_DIR_OWNER}" != "${CURRENT_USER}" ]; then
-    info "Ajustando dono de ${COMPOSE_DIR} para ${CURRENT_USER}..."
-    sudo chown "${CURRENT_USER}:${CURRENT_USER}" "${COMPOSE_DIR}" \
-        || warn "Não foi possível alterar o dono de ${COMPOSE_DIR}"
+# Verificar permissões do diretório do assistente
+SCRIPT_DIR_OWNER=$(stat -c '%U' "${SCRIPT_DIR}" 2>/dev/null || echo "")
+if [ "${SCRIPT_DIR_OWNER}" != "${CURRENT_USER}" ]; then
+    info "Ajustando dono de ${SCRIPT_DIR} para ${CURRENT_USER}..."
+    sudo chown -R "${CURRENT_USER}:${CURRENT_USER}" "${SCRIPT_DIR}" \
+        || warn "Não foi possível alterar o dono de ${SCRIPT_DIR}"
     ok "Permissões ajustadas"
 else
-    ok "Permissões de ${COMPOSE_DIR} corretas (dono: ${CURRENT_USER})"
+    ok "Permissões de ${SCRIPT_DIR} corretas (dono: ${CURRENT_USER})"
 fi
 
-# ════════════════════════════════════════════════════════════════════════════
-step "FASE 4 — Arquivos da stack"
-# ════════════════════════════════════════════════════════════════════════════
-
 # docker-compose.prd.external-db.yml
-COMPOSE_FILE_PATH="${COMPOSE_DIR}/${COMPOSE_FILE}"
+COMPOSE_FILE_PATH="${SCRIPT_DIR}/${COMPOSE_FILE}"
 if [ -f "${COMPOSE_FILE_PATH}" ]; then
     ok "${COMPOSE_FILE} presente"
 else
-    # Tentar copiar do diretório do script (se distribuídos juntos)
-    if [ -f "${SCRIPT_DIR}/${COMPOSE_FILE}" ]; then
-        cp "${SCRIPT_DIR}/${COMPOSE_FILE}" "${COMPOSE_FILE_PATH}"
-        ok "${COMPOSE_FILE} copiado de ${SCRIPT_DIR}"
-    else
-        printf "\n${RED}  ARQUIVO OBRIGATÓRIO AUSENTE: %s${NC}\n\n" "${COMPOSE_FILE}"
-        printf "  Coloque o arquivo fornecido pela equipe Prisma Educação em:\n"
-        printf "  ${CYAN}%s${NC}\n\n" "${COMPOSE_FILE_PATH}"
-        fail "Execute o script novamente após colocar ${COMPOSE_FILE} em ${COMPOSE_DIR}"
-    fi
+    printf "\n${RED}  ARQUIVO OBRIGATÓRIO AUSENTE: %s${NC}\n\n" "${COMPOSE_FILE}"
+    printf "  O arquivo deveria estar no repositório clonado.\n"
+    printf "  Verifique se o clone foi feito corretamente:\n"
+    printf "  ${CYAN}git clone https://github.com/Prisma-Consultoria/assistente-siscan-rpa.git${NC}\n\n"
+    fail "${COMPOSE_FILE} não encontrado em ${SCRIPT_DIR}"
 fi
 
 # config/
-CONFIG_DIR="${COMPOSE_DIR}/config"
+CONFIG_DIR="${SCRIPT_DIR}/config"
 if [ -d "${CONFIG_DIR}" ]; then
     ok "config/ presente"
     MAPPING_FILE="${CONFIG_DIR}/excel_columns_mapping.json"
@@ -386,18 +370,12 @@ if [ -d "${CONFIG_DIR}" ]; then
         ok "excel_columns_mapping.json presente"
     fi
 else
-    # Tentar copiar do diretório do script
-    if [ -d "${SCRIPT_DIR}/config" ]; then
-        cp -r "${SCRIPT_DIR}/config" "${CONFIG_DIR}"
-        ok "config/ copiado de ${SCRIPT_DIR}"
-    else
-        mkdir -p "${CONFIG_DIR}"
-        warn "config/ criado vazio — coloque excel_columns_mapping.json antes de iniciar a stack"
-    fi
+    mkdir -p "${CONFIG_DIR}"
+    warn "config/ criado vazio — coloque excel_columns_mapping.json antes de iniciar a stack"
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 5 — Configuração do .env"
+step "FASE 4 — Configuração do .env"
 # ════════════════════════════════════════════════════════════════════════════
 
 # Criar .env a partir do sample se não existir
@@ -405,9 +383,7 @@ if [ ! -f "${ENV_FILE}" ]; then
     # Procurar sample em ordem de preferência
     ENV_SAMPLE=""
     for candidate in \
-        "${COMPOSE_DIR}/.env.server.sample" \
         "${SCRIPT_DIR}/.env.server.sample" \
-        "${COMPOSE_DIR}/.env.host.sample" \
         "${SCRIPT_DIR}/.env.host.sample"; do
         if [ -f "${candidate}" ]; then
             ENV_SAMPLE="${candidate}"
@@ -541,13 +517,13 @@ for var in "${HOST_PATH_VARS[@]}"; do
 done
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 6 — Criação dos diretórios HOST_*"
+step "FASE 5 — Criação dos diretórios HOST_*"
 # ════════════════════════════════════════════════════════════════════════════
 
 ensure_host_paths "${ENV_FILE}"
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 7 — GitHub Actions Runner"
+step "FASE 6 — GitHub Actions Runner"
 # ════════════════════════════════════════════════════════════════════════════
 
 RUNNER_ALREADY_INSTALLED=false
@@ -650,7 +626,7 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 8 — Permissões Docker"
+step "FASE 7 — Permissões Docker"
 # ════════════════════════════════════════════════════════════════════════════
 
 if id -nG "${CURRENT_USER}" 2>/dev/null | grep -qw docker; then
@@ -666,12 +642,12 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
-step "FASE 8.5 — Persistir DIR_SISCAN_ASSISTENTE"
+step "FASE 8 — Persistir DIR_SISCAN_ASSISTENTE"
 # ════════════════════════════════════════════════════════════════════════════
 
 info "DIR_SISCAN_ASSISTENTE=${DIR_SISCAN_ASSISTENTE}"
 _persist_dir_siscan_assistente
-ok ".env do compose: ${COMPOSE_DIR}/.env"
+ok ".env do compose: ${SCRIPT_DIR}/.env"
 if [ -d "${RUNNER_DIR}" ]; then
     ok ".env do runner:  ${RUNNER_DIR}/.env"
 else
@@ -686,8 +662,8 @@ step "FASE 9 — Resumo e próximos passos"
 printf "  ${GREEN}Setup concluído!${NC}\n\n"
 
 printf "  ${WHITE}O que foi configurado:${NC}\n"
-ok "Stack:      ${COMPOSE_DIR}"
-ok "Compose:    ${COMPOSE_DIR}/${COMPOSE_FILE}"
+ok "Stack:      ${SCRIPT_DIR}"
+ok "Compose:    ${SCRIPT_DIR}/${COMPOSE_FILE}"
 ok "Env:        ${ENV_FILE}"
 ok "Runner:     ${RUNNER_DIR}"
 ok "Label:      ${RUNNER_LABEL}"
@@ -712,15 +688,15 @@ printf "  5. Para acompanhar os logs do runner:\n"
 printf "     ${CYAN}journalctl -u actions.runner.*.service -f${NC}\n\n"
 
 printf "  6. Para acompanhar os logs da stack após o primeiro deploy:\n"
-printf "     ${CYAN}docker compose -f %s/%s logs -f${NC}\n\n" "${COMPOSE_DIR}" "${COMPOSE_FILE}"
+printf "     ${CYAN}docker compose -f %s/%s logs -f${NC}\n\n" "${SCRIPT_DIR}" "${COMPOSE_FILE}"
 
 printf "  ${GRAY}Referência completa: docs/DEPLOY_AUTOMATICO.md — Opção 1.A${NC}\n\n"
 
 printf "${CYAN}══════════════════════════════════════════════════${NC}\n"
 printf "  ${WHITE}Você está em:${NC} $(pwd)\n"
-printf "  ${WHITE}Diretório da stack:${NC} ${COMPOSE_DIR}\n"
+printf "  ${WHITE}Diretório da stack:${NC} ${SCRIPT_DIR}\n"
 printf "${CYAN}══════════════════════════════════════════════════${NC}\n\n"
 printf "  Para ir ao diretório da stack:\n"
-printf "  ${CYAN}cd %s${NC}\n\n" "${COMPOSE_DIR}"
+printf "  ${CYAN}cd %s${NC}\n\n" "${SCRIPT_DIR}"
 
 fi # fim do guard BASH_SOURCE


### PR DESCRIPTION
## Summary

- **Persistir `DIR_SISCAN_ASSISTENTE`** em 3 locais (`.env` do compose, `.env` do runner, `/etc/environment`) para que o workflow de CD consiga localizar a stack no servidor de cada parceiro
- **Remover `COMPOSE_DIR`** — elimina o conceito de diretório separado para a stack; o `.env`, compose file e `config/` ficam no próprio diretório do clone
- **Atualizar documentação** para refletir a nova estrutura simplificada

## Motivação

O workflow de CD (`cd_imagem_certificada_selfhosted.yml`) usa `DIR_SISCAN_ASSISTENTE` para localizar `.env` e compose file no servidor. Havia dois problemas:

1. **Runner systemd não carrega `~/.bashrc` nem `/etc/environment`** — a variável precisa estar em `~/actions-runner/.env`
2. **`COMPOSE_DIR` (default `/opt/siscan-rpa`) criava um diretório separado do clone** — o `.env` era criado lá, mas `DIR_SISCAN_ASSISTENTE` apontava para o clone (`SCRIPT_DIR`), causando desencontro

A solução: a stack vive no diretório do clone. O parceiro escolhe onde clonar e tudo fica lá.

## Arquivos alterados

| Arquivo | O que muda |
|---|---|
| `siscan-server-setup.sh` | Remove `COMPOSE_DIR`, usa `SCRIPT_DIR` para tudo, nova Fase 8 (persistir variável), fases renumeradas 1-9 |
| `siscan-assistente.sh` | Exporta `DIR_SISCAN_ASSISTENTE`, persiste no `.env` e `/etc/environment` |
| `docs/DEPLOY_SERVER.md` | Fases atualizadas, `COMPOSE_DIR` removido, nova seção Fase 8, referência da variável |
| `docs/DEPLOY_HOST.md` | Nota sobre `DIR_SISCAN_ASSISTENTE` no Linux |

## Test plan

- [x] `bash -n siscan-server-setup.sh` — syntax OK
- [x] 63/63 testes bats passando
- [ ] Executar `siscan-server-setup.sh` em servidor limpo — verificar que `DIR_SISCAN_ASSISTENTE` aparece nos 3 locais
- [ ] Executar workflow de CD — verificar que diagnóstico e deploy leem a variável corretamente
- [ ] Verificar que `.env` é criado no diretório do clone (não em `/opt/siscan-rpa`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)