### PR TITLE
refs #24 adiciona suporte a Redis e enriquece documentação de deploy

### DIFF
--- a/.env.help.json
+++ b/.env.help.json
@@ -190,6 +190,34 @@
       "required": false,
       "type": "string",
       "secret": false
+    },
+    "REDIS_HOST": {
+      "help": "Hostname do Redis do ponto de vista dos containers. No compose padrão é 'redis' (serviço local). Altere se o Redis estiver em outro servidor.",
+      "example": "redis",
+      "required": false,
+      "type": "string",
+      "secret": false
+    },
+    "REDIS_PORT": {
+      "help": "Porta TCP do Redis. Use 6379 (padrão do Redis) salvo se o serviço estiver em porta customizada.",
+      "example": "6379",
+      "required": false,
+      "type": "number",
+      "secret": false
+    },
+    "CACHE_TIMEOUT": {
+      "help": "TTL padrão do cache operacional do dashboard em segundos. Consultas filtradas ficam em cache por esse período. 300 = 5 minutos.",
+      "example": "300",
+      "required": false,
+      "type": "number",
+      "secret": false
+    },
+    "CACHE_KEY_PREFIX": {
+      "help": "Prefixo das chaves do dashboard no Redis. Evita colisão com outros serviços que compartilhem o mesmo Redis. Altere apenas se houver mais de uma instância do dashboard no mesmo Redis.",
+      "example": "siscan-dashboard:cache",
+      "required": false,
+      "type": "string",
+      "secret": false
     }
   }
 }

--- a/.env.help.json
+++ b/.env.help.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1",
-  "updated_at": "2026-03-18",
+  "version": "1.2",
+  "updated_at": "2026-03-24",
   "keys": {
     "HOST_APP_EXTERNAL_PORT": {
       "help": "Porta TCP publicada no host. Define a URL de acesso: http://HOST:<porta>. Ajuste se houver proxy reverso ou conflito de porta.",

--- a/.env.host.sample
+++ b/.env.host.sample
@@ -156,6 +156,11 @@ HOST_DASHBOARD_LOG_DIR=C:\siscan-rpa\logs\dashboard
 # DASHBOARD_SECRETARIA_PASSWORD=
 # DASHBOARD_ROCHE_PASSWORD=
 
+# TTL padrão do cache operacional do dashboard em segundos. 300 = 5 minutos.
+CACHE_TIMEOUT=300
+# Prefixo das chaves do dashboard no Redis. Evita colisão com outros serviços.
+CACHE_KEY_PREFIX=siscan-dashboard:cache
+
 # Produto gerenciado por esta instalação do assistente.
 SISCAN_PRODUCT=full
 

--- a/.env.server-dashboard.sample
+++ b/.env.server-dashboard.sample
@@ -89,7 +89,19 @@ SYNC_INTERVAL_SECONDS=1800
 HOST_LOG_DIR=/opt/siscan-dashboard/logs
 
 # -----------------------------------------------------------------------------
-# 8) OPCIONAL
+# 8) REDIS E CACHE
+# -----------------------------------------------------------------------------
+# Host do Redis do ponto de vista dos containers. Default: redis (serviço local).
+REDIS_HOST=redis
+# Porta TCP do Redis.
+REDIS_PORT=6379
+# TTL padrão do cache operacional em segundos. 300 = 5 minutos.
+CACHE_TIMEOUT=300
+# Prefixo das chaves do dashboard no Redis. Evita colisão com outros serviços.
+CACHE_KEY_PREFIX=siscan-dashboard:cache
+
+# -----------------------------------------------------------------------------
+# 9) OPCIONAL
 # -----------------------------------------------------------------------------
 # Timezone operacional. Omita para usar o padrão (America/Sao_Paulo).
 # TZ=America/Sao_Paulo

--- a/docker-compose.prd.dashboard.yml
+++ b/docker-compose.prd.dashboard.yml
@@ -30,13 +30,25 @@ x-app-common-env: &app-common-env
   SQLALCHEMY_POOL_TIMEOUT: ${SQLALCHEMY_POOL_TIMEOUT:-30}
   SQLALCHEMY_POOL_RECYCLE: ${SQLALCHEMY_POOL_RECYCLE:-300}
   PYTHONUNBUFFERED: "1"
+  REDIS_HOST: ${REDIS_HOST:-redis}
+  REDIS_PORT: ${REDIS_PORT:-6379}
+  CACHE_TIMEOUT: ${CACHE_TIMEOUT:-300}
+  CACHE_KEY_PREFIX: ${CACHE_KEY_PREFIX:-siscan-dashboard:cache}
   TZ: ${TZ:-America/Sao_Paulo}
 
 services:
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--appendonly", "no"]
+    restart: unless-stopped
+
   migrate:
     image: ghcr.io/prisma-consultoria/siscan-dashboard:main
     restart: "no"
     environment: *app-common-env
+    depends_on:
+      redis:
+        condition: service_started
     command: ["alembic", "upgrade", "head"]
 
   app:
@@ -45,6 +57,8 @@ services:
     depends_on:
       migrate:
         condition: service_completed_successfully
+      redis:
+        condition: service_started
     environment: *app-common-env
     ports:
       - "${HOST_APP_EXTERNAL_PORT:-5000}:5000"
@@ -79,6 +93,8 @@ services:
     depends_on:
       migrate:
         condition: service_completed_successfully
+      redis:
+        condition: service_started
     environment:
       <<: *app-common-env
       SYNC_INTERVAL_SECONDS: ${SYNC_INTERVAL_SECONDS:-1800}

--- a/docs/DEPLOY_HOST.md
+++ b/docs/DEPLOY_HOST.md
@@ -58,13 +58,13 @@ flowchart TD
     style DB_RPA fill:#336791,color:#fff
     style DB_DASH fill:#336791,color:#fff
     style REDIS fill:#d97706,color:#fff
+    linkStyle 7 stroke:#336791,stroke-width:2px
+    linkStyle 8 stroke:#336791,stroke-width:2px
     linkStyle 9 stroke:#336791,stroke-width:2px
     linkStyle 10 stroke:#336791,stroke-width:2px
     linkStyle 11 stroke:#336791,stroke-width:2px
-    linkStyle 12 stroke:#336791,stroke-width:2px
-    linkStyle 13 stroke:#336791,stroke-width:2px
-    linkStyle 14 stroke:#d97706,stroke-width:2px
-    linkStyle 15 stroke:#d97706,stroke-width:2px
+    linkStyle 12 stroke:#d97706,stroke-width:2px
+    linkStyle 13 stroke:#d97706,stroke-width:2px
 ```
 
 O diagrama mostra como os containers se organizam e se conectam:

--- a/docs/DEPLOY_HOST.md
+++ b/docs/DEPLOY_HOST.md
@@ -1,8 +1,8 @@
 # Guia de Deploy — Modo HOST (PC local)
 <a name="deploy-host"></a>
 
-Versão: 2.0
-Data: 2026-03-23
+Versão: 2.1
+Data: 2026-03-24
 
 Deploy em PC local (Windows ou Linux) com Docker Desktop. O banco de dados PostgreSQL roda em container local junto com as aplicações. No modo HOST, o assistente opera como produto `full` — gerenciando tanto o siscan-rpa quanto o siscan-dashboard em uma única stack.
 

--- a/docs/DEPLOY_HOST.md
+++ b/docs/DEPLOY_HOST.md
@@ -82,6 +82,7 @@ A tabela a seguir detalha cada container, sua imagem, porta exposta e função.
 | Container | Imagem | Porta | Função |
 |---|---|---|---|
 | `db` | `postgres:17` | — | PostgreSQL com `siscan_rpa` + `siscan_dashboard` (init script cria o segundo banco) |
+| `redis` | `redis:7-alpine` | — | Cache operacional e payloads pré-calculados do dashboard |
 | `migrate` | `siscan-rpa-rpa:main` | — | Alembic migrations do RPA (efêmero) |
 | `app` | `siscan-rpa-rpa:main` | 5001 | Painel web do RPA |
 | `rpa-scheduler` | `siscan-rpa-rpa:main` | — | Coleta automática do SISCAN |
@@ -110,26 +111,36 @@ Antes de prosseguir, verifique os itens da tabela a seguir. Todos os passos são
 
 ## Instalação
 
-A instalação consiste em clonar o repositório do assistente, configurar o `.env` e executar o assistente para baixar as imagens Docker.
+No modo HOST, a instalação é feita pelo assistente interativo (`siscan-assistente.sh` ou `siscan-assistente.ps1`), que guia o operador em três etapas: clonar o repositório, configurar as variáveis de ambiente e baixar as imagens Docker do siscan-rpa e do siscan-dashboard. Não é necessário instalar PostgreSQL nem Redis separadamente — ambos sobem como containers gerenciados pelo compose.
 
-### Clonar o repositório
+### Etapa 1 — Clonar o repositório
+
+Clone o repositório do assistente no PC que receberá a instalação. Esse diretório será o diretório da stack — o compose, o `.env` e os scripts operacionais ficam aqui.
 
 ```bash
 git clone https://github.com/Prisma-Consultoria/assistente-siscan-rpa.git
 cd assistente-siscan-rpa
 ```
 
-### Configurar o `.env`
+### Etapa 2 — Configurar o `.env`
+
+Copie o sample e preencha os valores obrigatórios antes de executar o assistente pela primeira vez.
 
 ```bash
 cp .env.host.sample .env
 ```
 
-Preencha os caminhos das pastas, a senha do banco e a senha do admin do dashboard antes de iniciar o assistente pela primeira vez. A seção [Referência de variáveis](#referência-de-variáveis--env) abaixo documenta todas as variáveis.
+Os itens que precisam ser preenchidos nesta etapa são:
 
-### Executar o assistente
+1. **`DATABASE_PASSWORD`** — altere a senha padrão `siscan_rpa` para uma senha segura. Essa senha será usada pelo PostgreSQL do container.
+2. **`DASHBOARD_ADMIN_PASSWORD`** — defina a senha do usuário administrador do dashboard.
+3. **Caminhos `HOST_*`** — preencha os caminhos onde o sistema guardará logs, PDFs, relatórios e configurações. No Windows use barras invertidas (`C:\siscan-rpa\logs`); no Linux use barras normais (`/opt/siscan-rpa/logs`).
 
-Na primeira execução, o assistente solicita o **usuário GitHub** e o **token PAT** para autenticar no GHCR. Essas credenciais são salvas em `credenciais.txt` e reutilizadas nas execuções seguintes.
+A seção [Referência de variáveis](#referência-de-variáveis--env) abaixo documenta todas as variáveis em detalhe.
+
+### Etapa 3 — Executar o assistente
+
+Na primeira execução, o assistente solicita o **usuário GitHub** e o **token PAT** (com permissão `read:packages`) para autenticar no GHCR e baixar as imagens Docker. Essas credenciais são salvas em `credenciais.txt` e reutilizadas nas execuções seguintes.
 
 **Windows — PowerShell 7+:**
 ```powershell
@@ -151,7 +162,7 @@ bash ./siscan-assistente.sh
 
 > Na primeira execução (Linux), o script define `COMPOSE_DIR` apontando para o diretório onde o repositório foi clonado. Ela é persistida em `/etc/environment` para sessões interativas.
 
-Escolha a **Opção 2 — Atualizar / Instalar** no menu para realizar a primeira instalação. O assistente faz o pull de **duas imagens**: `siscan-rpa-rpa:main` e `siscan-dashboard:main`.
+Ao abrir o menu, escolha a **Opção 2 — Atualizar / Instalar** para realizar a primeira instalação. O assistente autentica no GHCR e faz o pull de **três imagens**: `postgres:17`, `redis:7-alpine`, `siscan-rpa-rpa:main` e `siscan-dashboard:main`. Em seguida, sobe a stack completa com todos os containers descritos no diagrama acima.
 
 ---
 
@@ -183,9 +194,9 @@ O `.env.host.sample` cobre o modo HOST (`docker-compose.prd.host.yml`). As tabel
 - **Obrigatória?** — se precisa ser preenchida antes de subir.
 - **O que é** — explicação em linguagem simples.
 
-### Aplicação HTTP (RPA)
+### Aplicação HTTP (siscan-rpa)
 
-A tabela a seguir descreve as variáveis da aplicação web do RPA, acessível na porta 5001.
+A tabela a seguir descreve as variáveis da aplicação web do siscan-rpa, acessível na porta 5001.
 
 | Variável | `.env.host.sample` | Default no compose | Obrigatória? | O que é |
 |---|---|---|---|---|
@@ -193,9 +204,9 @@ A tabela a seguir descreve as variáveis da aplicação web do RPA, acessível n
 | `APP_LOG_LEVEL` | `INFO` | `:-INFO` | Não | Detalhe dos logs. `DEBUG` só com orientação técnica. |
 | `SECRET_KEY` | *(vazio — gerado pelo assistente)* | sem fallback | **Sim** | Chave de segurança do painel web. Gerada automaticamente. |
 
-### Dashboard
+### siscan-dashboard
 
-A tabela a seguir descreve as variáveis da aplicação dashboard, acessível na porta 5000.
+A tabela a seguir descreve as variáveis do siscan-dashboard, acessível na porta 5000.
 
 | Variável | `.env.host.sample` | Default no compose | Obrigatória? | O que é |
 |---|---|---|---|---|
@@ -220,7 +231,7 @@ O banco PostgreSQL é gerenciado pelo Docker — não é necessário instalar na
 | `DATABASE_PORT` | `5432` | `:-5432` | Não | Porta interna do banco. |
 | `DATABASE_HOST` | `db` | `:-db` | Não | Endereço do banco no Docker — **não altere**. |
 
-### Scheduler batch (RPA)
+### Scheduler batch (siscan-rpa)
 
 | Variável | `.env.host.sample` | Default no compose | Obrigatória? | O que é |
 |---|---|---|---|---|
@@ -253,10 +264,10 @@ Para variáveis opcionais e avançadas (pool de conexões, timeouts Playwright, 
 
 Após subir a stack pela primeira vez, acesse as aplicações conforme a tabela a seguir.
 
-| Aplicação | URL padrão | Próximo passo |
+| Sistema | URL padrão | Próximo passo |
 |---|---|---|
-| RPA | `http://localhost:5001` | Navegar até `/admin/siscan-credentials` e cadastrar usuário/senha do SISCAN |
-| Dashboard | `http://localhost:5000` | Login com admin / senha definida em `DASHBOARD_ADMIN_PASSWORD` |
+| siscan-rpa | `http://localhost:5001` | Navegar até `/admin/siscan-credentials` e cadastrar usuário/senha do SISCAN |
+| siscan-dashboard | `http://localhost:5000` | Login com admin / senha definida em `DASHBOARD_ADMIN_PASSWORD` |
 
 A coleta automática do RPA inicia no próximo ciclo agendado (padrão: 30 minutos). O sync do dashboard roda automaticamente no mesmo intervalo.
 

--- a/docs/DEPLOY_HOST.md
+++ b/docs/DEPLOY_HOST.md
@@ -193,6 +193,8 @@ A tabela a seguir descreve as variáveis da aplicação dashboard, acessível na
 | `DASHBOARD_WEB_CONCURRENCY` | `2` | `:-2` | Não | Workers Gunicorn do dashboard. |
 | `SYNC_INTERVAL_SECONDS` | `1800` | `:-1800` | Não | Intervalo do sync em segundos (30 min). |
 | `HOST_DASHBOARD_LOG_DIR` | `C:\siscan-rpa\logs\dashboard` | `:-./logs/dashboard` | Não | Pasta de logs do dashboard. |
+| `CACHE_TIMEOUT` | `300` | `:-300` | Não | TTL do cache operacional em segundos. |
+| `CACHE_KEY_PREFIX` | `siscan-dashboard:cache` | `:-siscan-dashboard:cache` | Não | Prefixo das chaves do dashboard no Redis. |
 
 ### Banco de dados
 

--- a/docs/DEPLOY_HOST.md
+++ b/docs/DEPLOY_HOST.md
@@ -31,6 +31,7 @@ flowchart TD
             D_MIG["dashboard-migrate\nalembic (efêmero)"]
             D_APP["dashboard-app\nporta 5000"]
             D_SYNC["dashboard-sync\nsync a cada 30 min"]
+            REDIS[("Redis\ncache")]
         end
     end
 
@@ -49,13 +50,19 @@ flowchart TD
     D_APP -->|"lê"| DB_DASH
     D_SYNC -->|"lê"| DB_RPA
     D_SYNC -->|"escreve"| DB_DASH
+    D_APP --> REDIS
+    D_SYNC --> REDIS
 
-    style DB_RPA fill:#e8f4f8,stroke:#17a2b8
-    style DB_DASH fill:#d4edda,stroke:#27ae60
-    style R_APP fill:#e8f4f8,stroke:#17a2b8
-    style R_SCHED fill:#e8f4f8,stroke:#17a2b8
-    style D_APP fill:#d4edda,stroke:#27ae60
-    style D_SYNC fill:#fff3cd,stroke:#f39c12
+    style DB_RPA fill:#336791,color:#fff
+    style DB_DASH fill:#336791,color:#fff
+    style REDIS fill:#d97706,color:#fff
+    linkStyle 9 stroke:#336791,stroke-width:2px
+    linkStyle 10 stroke:#336791,stroke-width:2px
+    linkStyle 11 stroke:#336791,stroke-width:2px
+    linkStyle 12 stroke:#336791,stroke-width:2px
+    linkStyle 13 stroke:#336791,stroke-width:2px
+    linkStyle 14 stroke:#d97706,stroke-width:2px
+    linkStyle 15 stroke:#d97706,stroke-width:2px
 ```
 
 Pontos relevantes do diagrama:

--- a/docs/DEPLOY_HOST.md
+++ b/docs/DEPLOY_HOST.md
@@ -181,6 +181,21 @@ O menu se adapta ao produto detectado via `SISCAN_PRODUCT` no `.env`. No modo HO
 | **7 — Atualizar o Assistente** | Baixa a versão mais recente dos scripts com rollback automático. |
 | **8 — Sair** | Encerra o assistente. Os containers continuam rodando. |
 
+### Atualização do assistente (Opção 7)
+
+Após a instalação inicial, o assistente permanece na versão do clone original. Quando a equipe publica uma nova versão — com novas variáveis de ambiente, correções nos scripts ou alterações nos compose files — é necessário atualizar.
+
+No modo HOST, use a **Opção 7** do menu. Ela baixa a versão mais recente do script diretamente do GitHub, cria um backup automático do script atual (com timestamp) e substitui pelo novo. Se o download falhar, o backup é restaurado automaticamente (rollback).
+
+A Opção 7 atualiza apenas o script do assistente (`siscan-assistente.sh` ou `siscan-assistente.ps1`). Para atualizar também os compose files, `.env` samples e demais arquivos do repositório, execute manualmente:
+
+```bash
+cd assistente-siscan-rpa
+git pull origin main
+```
+
+Se a atualização incluir novas variáveis de ambiente, adicione-as ao `.env` existente. O `.env` não é sobrescrito pelo `git pull` — ele não é versionado. Consulte o `.env.host.sample` atualizado para identificar variáveis novas, ou use a **Opção 3 — Editar configurações** para revisar e completar as variáveis interativamente.
+
 ---
 
 ## Referência de variáveis — `.env`

--- a/docs/DEPLOY_HOST.md
+++ b/docs/DEPLOY_HOST.md
@@ -10,7 +10,9 @@ Deploy em PC local (Windows ou Linux) com Docker Desktop. O banco de dados Postg
 
 ## O que sobe no modo HOST
 
-No modo HOST, o compose `docker-compose.prd.host.yml` cria 7 containers a partir de um único banco PostgreSQL com dois databases. O diagrama a seguir ilustra a arquitetura dos containers, suas dependências de inicialização e as conexões com os bancos de dados.
+O sistema SISCAN opera com dois produtos: o **siscan-rpa**, responsável pela coleta automatizada de dados do portal SISCAN via navegador, e o **siscan-dashboard**, um painel analítico que exibe indicadores de câncer de mama a partir dos dados coletados. No modo HOST, ambos rodam em um único PC com Docker Desktop.
+
+O compose `docker-compose.prd.host.yml` cria 8 containers a partir de um único banco PostgreSQL com dois databases. O diagrama a seguir ilustra a arquitetura dos containers, suas dependências de inicialização e as conexões com os bancos de dados.
 
 ```mermaid
 flowchart TD
@@ -65,12 +67,15 @@ flowchart TD
     linkStyle 15 stroke:#d97706,stroke-width:2px
 ```
 
-Pontos relevantes do diagrama:
+O diagrama mostra como os containers se organizam e se conectam:
 
-- O container `db` hospeda **dois bancos** na mesma instância PostgreSQL. O script `init-databases.sh` cria o banco `siscan_dashboard` automaticamente — o `siscan_rpa` é criado pelo entrypoint padrão do PostgreSQL.
-- O `dashboard-sync` é o único container que acessa **ambos os bancos**: lê do `siscan_rpa` e escreve no `siscan_dashboard`. Todos os demais acessam apenas seu próprio banco.
-- Os containers `migrate` e `dashboard-migrate` são efêmeros — executam as migrations e encerram. Os serviços `app`, `rpa-scheduler`, `dashboard-app` e `dashboard-sync` só sobem após a conclusão das respectivas migrations.
-- Ambas as imagens (`siscan-rpa-rpa:main` e `siscan-dashboard:main`) são baixadas do GHCR via a Opção 2 do menu do assistente.
+1. O **PostgreSQL** (container `db`) hospeda dois bancos na mesma instância: `siscan_rpa` e `siscan_dashboard`. O script `init-databases.sh` cria o banco do dashboard automaticamente na primeira inicialização — o banco do RPA é criado pelo entrypoint padrão do PostgreSQL.
+2. O grupo **SISCAN RPA** tem três containers. O `migrate` executa as migrations do banco do RPA e encerra (efêmero). O `app` (porta 5001) serve o painel administrativo do RPA via Gunicorn. O `rpa-scheduler` executa as coletas automatizadas no portal SISCAN em intervalos configuráveis.
+3. O grupo **SISCAN Dashboard** tem quatro containers. O `dashboard-migrate` executa as migrations do banco do dashboard e encerra (efêmero). O `dashboard-app` (porta 5000) serve o painel analítico via Gunicorn. O `dashboard-sync` importa dados do banco do RPA para o banco do dashboard a cada 30 minutos. O **Redis** serve como cache operacional compartilhado entre os workers do Gunicorn e armazena os payloads pré-calculados que aceleram a carga inicial do dashboard.
+4. O `dashboard-sync` é o único container que acessa **ambos os bancos**: lê do `siscan_rpa` e escreve no `siscan_dashboard`. Todos os demais acessam apenas seu próprio banco.
+5. Os containers de migration só executam uma vez — os serviços `app`, `rpa-scheduler`, `dashboard-app` e `dashboard-sync` só sobem após a conclusão das respectivas migrations.
+6. As setas em <span style="color:#336791">**azul**</span> representam conexões com o PostgreSQL. As setas em <span style="color:#d97706">**âmbar**</span> representam conexões com o Redis.
+7. Ambas as imagens (`siscan-rpa-rpa:main` e `siscan-dashboard:main`) são baixadas do GHCR via a Opção 2 do menu do assistente.
 
 A tabela a seguir detalha cada container, sua imagem, porta exposta e função.
 

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -384,9 +384,45 @@ O runner registrado na fase 7 receberá automaticamente os próximos deploys via
 
 ---
 
+## Atualização do assistente
+
+Após a instalação inicial, o assistente não se atualiza sozinho. Os deploys automáticos via GitHub Actions atualizam as **imagens Docker** e o **compose file** do produto (o workflow baixa o compose mais recente do repositório do assistente a cada deploy). No entanto, os scripts do assistente, os `.env` samples e a documentação permanecem na versão do clone original.
+
+Para atualizar o assistente no servidor — por exemplo, quando há novas variáveis de ambiente, correções nos scripts ou novos compose files — execute os seguintes comandos na VM correspondente:
+
+```bash
+# Ir para o diretório do assistente (onde foi feito o clone)
+cd /app/assistente-siscan-rpa   # ajuste conforme o caminho da sua instalação
+
+# Atualizar para a versão mais recente
+git pull origin main
+
+# Verificar que os arquivos estão atualizados
+ls -la docker-compose.prd.*.yml
+cat .env.server-*.sample
+```
+
+Se a atualização incluir novas variáveis de ambiente (como foi o caso da adição do Redis), adicione-as manualmente ao `.env` existente. O `.env` não é sobrescrito pelo `git pull` — ele não é versionado. Consulte o `.env.server-rpa.sample` ou `.env.server-dashboard.sample` atualizado para identificar variáveis novas.
+
+Após atualizar, se houver alteração no compose file, reinicie a stack para aplicar:
+
+```bash
+# siscan-rpa (VM 1):
+docker compose -f docker-compose.prd.rpa.yml down
+docker compose -f docker-compose.prd.rpa.yml up -d --wait
+
+# siscan-dashboard (VM 3):
+docker compose -f docker-compose.prd.dashboard.yml down
+docker compose -f docker-compose.prd.dashboard.yml up -d --wait
+```
+
+> No modo HOST (PC local), o assistente oferece a **Opção 7 — Atualizar o Assistente** no menu interativo, que baixa a versão mais recente do script automaticamente. No modo SERVER, a atualização é feita manualmente via `git pull` conforme descrito acima.
+
+---
+
 ## Comandos úteis
 
-Os comandos a seguir cobrem as operações mais comuns. Substitua o compose file e a porta conforme o produto instalado na VM.
+Os comandos a seguir cobrem as operações mais comuns. Substitua o compose file e a porta conforme o sistema instalado na VM.
 
 ### siscan-rpa
 

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -386,7 +386,7 @@ O runner registrado na fase 7 receberá automaticamente os próximos deploys via
 
 ## Atualização do assistente
 
-Após a instalação inicial, o assistente não se atualiza sozinho. Os deploys automáticos via GitHub Actions atualizam as **imagens Docker** e o **compose file** do produto (o workflow baixa o compose mais recente do repositório do assistente a cada deploy). No entanto, os scripts do assistente, os `.env` samples e a documentação permanecem na versão do clone original.
+Após a instalação inicial, o assistente não se atualiza sozinho. Os deploys automáticos via GitHub Actions atualizam as **imagens Docker** e o **compose file** do produto a cada deploy — o workflow baixa o compose mais recente da branch `main` do repositório do assistente via `curl` e sobrescreve o arquivo local no `COMPOSE_DIR`. No entanto, os scripts do assistente, os `.env` samples e a documentação permanecem na versão do clone original.
 
 Para atualizar o assistente no servidor — por exemplo, quando há novas variáveis de ambiente, correções nos scripts ou novos compose files — execute os seguintes comandos na VM correspondente:
 
@@ -417,6 +417,23 @@ docker compose -f docker-compose.prd.dashboard.yml up -d --wait
 ```
 
 > No modo HOST (PC local), o assistente oferece a **Opção 7 — Atualizar o Assistente** no menu interativo, que baixa a versão mais recente do script automaticamente. No modo SERVER, a atualização é feita manualmente via `git pull` conforme descrito acima.
+
+### Compose file e `git pull` — por que não há conflito
+
+Os workflows de CD do siscan-rpa e do siscan-dashboard sobrescrevem o compose file no servidor a cada deploy, baixando a versão mais recente da branch `main` do assistente via `curl`. Como o conteúdo baixado é idêntico ao que está na `main` do repositório remoto, o `git pull` subsequente não detecta diferença e executa normalmente (fast-forward).
+
+O único cenário que causaria conflito é se o operador **modificar manualmente** o compose file no servidor. Nesse caso, o `git pull` recusaria o merge por haver alterações locais não commitadas. Para resolver, descarte as alterações locais antes do pull:
+
+```bash
+# Descartar alterações locais no compose (volta à versão do último commit)
+git checkout -- docker-compose.prd.rpa.yml
+git checkout -- docker-compose.prd.dashboard.yml
+
+# Agora o pull funciona normalmente
+git pull origin main
+```
+
+> **Recomendação:** nunca edite os compose files diretamente no servidor. Alterações nos composes devem ser feitas no repositório do assistente e propagadas via `git pull` ou automaticamente pelo workflow de CD.
 
 ---
 

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -386,25 +386,32 @@ O runner registrado na fase 7 receberá automaticamente os próximos deploys via
 
 ## Atualização do assistente
 
-Após a instalação inicial, o assistente não se atualiza sozinho. Os deploys automáticos via GitHub Actions atualizam as **imagens Docker** e o **compose file** do produto a cada deploy — o workflow baixa o compose mais recente da branch `main` do repositório do assistente via `curl` e sobrescreve o arquivo local no `COMPOSE_DIR`. No entanto, os scripts do assistente, os `.env` samples e a documentação permanecem na versão do clone original.
+Após a instalação inicial, o assistente não se atualiza sozinho. No entanto, os deploys automáticos via GitHub Actions já mantêm atualizados os arquivos mais importantes a cada deploy:
 
-Para atualizar o assistente no servidor — por exemplo, quando há novas variáveis de ambiente, correções nos scripts ou novos compose files — execute os seguintes comandos na VM correspondente:
+- **Imagens Docker** — o workflow faz pull da imagem mais recente do GHCR.
+- **Compose file** (`docker-compose.prd.*.yml`) — o workflow baixa a versão mais recente da branch `main` do assistente e sobrescreve o arquivo local no `COMPOSE_DIR`.
+- **`.env` sample** (`.env.server-*.sample`) — o workflow baixa o sample atualizado para o `COMPOSE_DIR`, servindo como referência para identificar novas variáveis.
+
+Isso significa que, **no modo SERVER, o `git pull` é opcional**. Os arquivos operacionais (compose e imagens) já são atualizados automaticamente pelo CD. O `git pull` seria útil apenas para atualizar scripts do assistente (`siscan-server-setup.sh`) e documentação (`docs/`), que raramente mudam após a instalação.
+
+Se ainda assim quiser atualizar o repositório completo:
 
 ```bash
-# Ir para o diretório do assistente (onde foi feito o clone)
 cd /app/assistente-siscan-rpa   # ajuste conforme o caminho da sua instalação
-
-# Atualizar para a versão mais recente
 git pull origin main
-
-# Verificar que os arquivos estão atualizados
-ls -la docker-compose.prd.*.yml
-cat .env.server-*.sample
 ```
 
-Se a atualização incluir novas variáveis de ambiente (como foi o caso da adição do Redis), adicione-as manualmente ao `.env` existente. O `.env` não é sobrescrito pelo `git pull` — ele não é versionado. Consulte o `.env.server-rpa.sample` ou `.env.server-dashboard.sample` atualizado para identificar variáveis novas.
+### Novas variáveis de ambiente
 
-Após atualizar, se houver alteração no compose file, reinicie a stack para aplicar:
+Quando uma nova versão do assistente introduz variáveis de ambiente novas (como foi o caso da adição do Redis com `REDIS_HOST`, `REDIS_PORT`, `CACHE_TIMEOUT`), o `.env` sample atualizado já estará disponível no servidor após o próximo deploy automático. Para identificar as variáveis novas, compare o sample com o `.env` em uso:
+
+```bash
+# Ver variáveis que existem no sample mas não no .env atual
+diff <(grep -E '^[A-Z_]+=' .env.server-rpa.sample | cut -d= -f1 | sort) \
+     <(grep -E '^[A-Z_]+=' .env | cut -d= -f1 | sort)
+```
+
+Adicione as variáveis faltantes manualmente ao `.env` e reinicie a stack para aplicar:
 
 ```bash
 # siscan-rpa (VM 1):
@@ -416,24 +423,21 @@ docker compose -f docker-compose.prd.dashboard.yml down
 docker compose -f docker-compose.prd.dashboard.yml up -d --wait
 ```
 
-> No modo HOST (PC local), o assistente oferece a **Opção 7 — Atualizar o Assistente** no menu interativo, que baixa a versão mais recente do script automaticamente. No modo SERVER, a atualização é feita manualmente via `git pull` conforme descrito acima.
+> No modo HOST (PC local), o assistente oferece a **Opção 7 — Atualizar o Assistente** no menu interativo, que baixa a versão mais recente do script automaticamente. A **Opção 3 — Editar configurações** permite revisar e completar variáveis novas interativamente.
 
 ### Compose file e `git pull` — por que não há conflito
 
-Os workflows de CD do siscan-rpa e do siscan-dashboard sobrescrevem o compose file no servidor a cada deploy, baixando a versão mais recente da branch `main` do assistente via `curl`. Como o conteúdo baixado é idêntico ao que está na `main` do repositório remoto, o `git pull` subsequente não detecta diferença e executa normalmente (fast-forward).
+Os workflows de CD sobrescrevem o compose file e o `.env` sample no servidor a cada deploy, baixando a versão mais recente da branch `main` do assistente via `curl`. Como o conteúdo baixado é idêntico ao que está na `main` do repositório remoto, o `git pull` subsequente não detecta diferença e executa normalmente (fast-forward).
 
-O único cenário que causaria conflito é se o operador **modificar manualmente** o compose file no servidor. Nesse caso, o `git pull` recusaria o merge por haver alterações locais não commitadas. Para resolver, descarte as alterações locais antes do pull:
+O único cenário que causaria conflito é se o operador **modificar manualmente** o compose file ou o sample no servidor. Nesse caso, o `git pull` recusaria o merge por haver alterações locais não commitadas. Para resolver, descarte as alterações locais antes do pull:
 
 ```bash
-# Descartar alterações locais no compose (volta à versão do último commit)
-git checkout -- docker-compose.prd.rpa.yml
-git checkout -- docker-compose.prd.dashboard.yml
-
-# Agora o pull funciona normalmente
+git checkout -- docker-compose.prd.rpa.yml docker-compose.prd.dashboard.yml
+git checkout -- .env.server-rpa.sample .env.server-dashboard.sample
 git pull origin main
 ```
 
-> **Recomendação:** nunca edite os compose files diretamente no servidor. Alterações nos composes devem ser feitas no repositório do assistente e propagadas via `git pull` ou automaticamente pelo workflow de CD.
+> **Recomendação:** nunca edite os compose files nem os `.env` samples diretamente no servidor. Alterações devem ser feitas no repositório do assistente e propagadas automaticamente pelo workflow de CD.
 
 ---
 

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -113,9 +113,9 @@ psql -h <DATABASE_HOST> -U siscan_rpa -c "SELECT version();"
 
 Cada VM precisa de um token de registro gerado no repositório correspondente ao produto:
 
-| Produto | Onde gerar o token |
+| Sistema | Onde gerar o token |
 |---|---|
-| `rpa` | [siscan-rpa → Settings → Actions → Runners → New](https://github.com/Prisma-Consultoria/siscan-rpa/settings/actions/runners/new) |
+| siscan-rpa | [siscan-rpa → Settings → Actions → Runners → New](https://github.com/Prisma-Consultoria/siscan-rpa/settings/actions/runners/new) |
 | `dashboard` | [siscan-dashboard → Settings → Actions → Runners → New](https://github.com/Prisma-Consultoria/siscan-dashboard/settings/actions/runners/new) |
 
 >  ⚠️  O token expira em poucos minutos. Gere-o imediatamente antes de executar o script.
@@ -242,10 +242,10 @@ O diretório da stack é o próprio diretório onde o assistente foi clonado. Os
 
 O script verifica se o compose file correspondente ao produto está presente no diretório da stack. Se não estiver, tenta copiar do diretório de origem do script (caso tenham sido distribuídos juntos). Se o arquivo não for encontrado em nenhum dos dois locais, o script interrompe com a instrução para o operador colocar o arquivo manualmente.
 
-| Produto | Compose file |
+| Sistema | Compose file |
 |---|---|
-| `rpa` | `docker-compose.prd.rpa.yml` |
-| `dashboard` | `docker-compose.prd.dashboard.yml` |
+| siscan-rpa | `docker-compose.prd.rpa.yml` |
+| siscan-dashboard | `docker-compose.prd.dashboard.yml` |
 
 Além do compose, o script verifica o diretório `config/` e a presença do arquivo `excel_columns_mapping.json` (necessário para o RPA). Se o `config/` não existir, tenta copiar do diretório de origem ou cria vazio com aviso.
 
@@ -260,10 +260,10 @@ O fluxo de perguntas segue esta ordem:
 1. **Chave de sessão** — gerada automaticamente sem intervenção do operador. Para o RPA, gera `SECRET_KEY`; para o dashboard, gera `SESSION_SECRET`. Ambas são chaves hexadecimais de 256 bits produzidas via `openssl rand -hex 32`.
 2. **`DATABASE_HOST`** — o script pergunta o IP ou hostname do PostgreSQL externo. Se o valor atual for `db` (padrão de desenvolvimento), avisa que é inválido para banco externo e solicita correção.
 3. **`DATABASE_PASSWORD`** — o script pergunta a senha do banco. Se detectar a senha padrão `siscan_rpa`, exibe aviso para alteração. A entrada é ocultada (não ecoa no terminal).
-4. **`RPA_DATABASE_URL`** (apenas para o produto dashboard) — o script solicita a connection string completa para o banco do RPA, exibindo o formato e um exemplo. Essa variável é obrigatória para que o `sync_exames` consiga ler os dados do RPA.
+4. **`RPA_DATABASE_URL`** (apenas para o siscan-dashboard) — o script solicita a connection string completa para o banco do RPA, exibindo o formato e um exemplo. Essa variável é obrigatória para que o `sync_exames` consiga ler os dados do RPA.
 5. **Diretórios `HOST_*`** — o script percorre cada variável de caminho, exibindo o valor atual e uma descrição. Se o valor atual parecer um caminho Windows (letra de drive, barras invertidas, UNC), exibe um aviso e sugere o equivalente Linux. O operador pode manter o valor atual pressionando Enter ou informar um novo caminho.
 
-| Variável | Produto RPA | Produto Dashboard |
+| Variável | siscan-rpa | siscan-dashboard |
 |---|---|---|
 | Chave de sessão | `SECRET_KEY` (auto-gerada) | `SESSION_SECRET` (auto-gerada) |
 | `DATABASE_HOST` | Pergunta (obrigatório) | Pergunta (obrigatório) |
@@ -295,7 +295,7 @@ Se o runner não estiver instalado, o fluxo completo é:
 6. **Registra o runner** com a label e o nome definidos pelo produto, usando `--unattended --replace`.
 7. **Instala como serviço systemd** e inicia o serviço. O runner passa a rodar em background e sobrevive a reinicializações do servidor.
 
-| Aspecto | Produto RPA | Produto Dashboard |
+| Aspecto | siscan-rpa | siscan-dashboard |
 |---|---|---|
 | Label | `producao-rpa` | `producao-dashboard` |
 | Nome | `<hostname>-siscan-rpa` | `<hostname>-siscan-dashboard` |
@@ -333,9 +333,9 @@ O script exibe um resumo completo do que foi configurado: produto, diretório da
 
 ## Referência de variáveis — `.env`
 
-As variáveis do `.env` são específicas de cada produto. As seções a seguir documentam as variáveis do produto **RPA** (`docker-compose.prd.rpa.yml`). Para as variáveis do produto **Dashboard** (`docker-compose.prd.dashboard.yml`), consulte o `.env.server-dashboard.sample` que acompanha o assistente.
+As variáveis do `.env` são específicas de cada sistema. As seções a seguir documentam as variáveis do **siscan-rpa** (`docker-compose.prd.rpa.yml`). Para as variáveis do **siscan-dashboard** (`docker-compose.prd.dashboard.yml`), consulte o `.env.server-dashboard.sample` que acompanha o assistente.
 
-### Aplicação HTTP (RPA)
+### Aplicação HTTP (siscan-rpa)
 
 | Variável | `.env.server-rpa.sample` | Default no compose | Obrigatória? | O que faz / Impacto |
 |---|---|---|---|---|
@@ -343,7 +343,7 @@ As variáveis do `.env` são específicas de cada produto. As seções a seguir 
 | `APP_LOG_LEVEL` | `INFO` | `:-INFO` | Não | Verbosidade dos logs. Use `INFO` em produção; `DEBUG` gera alto volume. |
 | `SECRET_KEY` | *(vazio — preencher)* | sem fallback | **Sim** | Assina cookies de sessão do painel web. Gere com `openssl rand -hex 32`. |
 
-### Banco de dados (RPA)
+### Banco de dados (siscan-rpa)
 
 | Variável | `.env.server-rpa.sample` | Default no compose | Obrigatória? | O que faz / Impacto |
 |---|---|---|---|---|
@@ -353,9 +353,9 @@ As variáveis do `.env` são específicas de cada produto. As seções a seguir 
 | `DATABASE_PORT` | `5432` | `:-5432` | Não | Porta TCP do PostgreSQL externo. |
 | `DATABASE_HOST` | *(vazio — preencher)* | **sem fallback** | **Sim** | IP ou hostname do PostgreSQL externo. |
 
-### Variáveis específicas do Dashboard
+### Variáveis específicas do siscan-dashboard
 
-A tabela a seguir lista variáveis que existem apenas no `.env.server-dashboard.sample` e não se aplicam ao produto RPA.
+A tabela a seguir lista variáveis que existem apenas no `.env.server-dashboard.sample` e não se aplicam ao siscan-rpa.
 
 | Variável | `.env.server-dashboard.sample` | Obrigatória? | O que faz |
 |---|---|---|---|
@@ -375,10 +375,10 @@ A tabela a seguir lista variáveis que existem apenas no `.env.server-dashboard.
 
 Após o primeiro deploy, acesse a aplicação conforme o produto instalado na VM.
 
-| Produto | URL padrão | Próximo passo |
+| Sistema | URL padrão | Próximo passo |
 |---|---|---|
-| RPA | `http://<IP>:5001` | Navegar até `/admin/siscan-credentials` e cadastrar usuário/senha do SISCAN |
-| Dashboard | `http://<IP>:5000` | Login com admin / senha definida em `ADMIN_PASSWORD` |
+| siscan-rpa | `http://<IP>:5001` | Navegar até `/admin/siscan-credentials` e cadastrar usuário/senha do SISCAN |
+| siscan-dashboard | `http://<IP>:5000` | Login com admin / senha definida em `ADMIN_PASSWORD` |
 
 O runner registrado na fase 7 receberá automaticamente os próximos deploys via GitHub Actions.
 
@@ -388,7 +388,7 @@ O runner registrado na fase 7 receberá automaticamente os próximos deploys via
 
 Os comandos a seguir cobrem as operações mais comuns. Substitua o compose file e a porta conforme o produto instalado na VM.
 
-### Produto RPA
+### siscan-rpa
 
 ```bash
 # Status dos containers
@@ -404,7 +404,7 @@ curl -s http://localhost:5001/health | python3 -m json.tool
 sudo ~/actions-runner/svc.sh status
 ```
 
-### Produto Dashboard
+### siscan-dashboard
 
 ```bash
 # Status dos containers

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -43,6 +43,7 @@ flowchart TD
         subgraph DASH_CONTAINERS["Containers"]
             DA["app (5000)"]
             DS["sync (loop 30min)"]
+            REDIS[("Redis\ncache")]
         end
     end
 
@@ -52,6 +53,17 @@ flowchart TD
     RS -->|"TCP 5432"| PG
     DA -->|"TCP 5432"| PG
     DS -->|"lê siscan_rpa\nescreve siscan_dashboard"| PG
+    DA --> REDIS
+    DS --> REDIS
+
+    style PG fill:#336791,color:#fff
+    style REDIS fill:#d97706,color:#fff
+    linkStyle 10 stroke:#336791,stroke-width:2px
+    linkStyle 11 stroke:#336791,stroke-width:2px
+    linkStyle 12 stroke:#336791,stroke-width:2px
+    linkStyle 13 stroke:#336791,stroke-width:2px
+    linkStyle 14 stroke:#d97706,stroke-width:2px
+    linkStyle 15 stroke:#d97706,stroke-width:2px
 ```
 
 Pontos relevantes do diagrama:
@@ -59,6 +71,7 @@ Pontos relevantes do diagrama:
 - Cada VM de aplicação recebe deploys de forma independente — o merge no siscan-rpa não afeta o dashboard e vice-versa.
 - O serviço `sync` no dashboard lê do banco `siscan_rpa` e escreve no banco `siscan_dashboard`, mantendo a tabela analítica atualizada a cada 30 minutos.
 - O banco de dados (VM 2) não tem runner nem assistente — é um PostgreSQL dedicado que atende ambas as aplicações.
+- O Redis roda na VM 3 como container local da stack do dashboard, servindo como cache operacional e armazenamento dos payloads pré-calculados.
 
 ---
 

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -297,6 +297,10 @@ A tabela a seguir lista variáveis que existem apenas no `.env.server-dashboard.
 | `SYNC_INTERVAL_SECONDS` | `1800` | Não | Intervalo do sync automático em segundos. |
 | `ADMIN_PASSWORD` | *(vazio)* | Sim (1ª exec.) | Senha do admin do dashboard. |
 | `HOST_DASHBOARD_EXTERNAL_PORT` | `5000` | Não | Porta TCP do dashboard. |
+| `REDIS_HOST` | `redis` | Não | Host do Redis. Default `redis` (serviço local no compose). |
+| `REDIS_PORT` | `6379` | Não | Porta TCP do Redis. |
+| `CACHE_TIMEOUT` | `300` | Não | TTL do cache operacional em segundos. |
+| `CACHE_KEY_PREFIX` | `siscan-dashboard:cache` | Não | Prefixo das chaves do dashboard no Redis. |
 
 ---
 

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -60,12 +60,12 @@ flowchart TD
 
     style PG fill:#336791,color:#fff
     style REDIS fill:#d97706,color:#fff
-    linkStyle 10 stroke:#336791,stroke-width:2px
     linkStyle 11 stroke:#336791,stroke-width:2px
     linkStyle 12 stroke:#336791,stroke-width:2px
     linkStyle 13 stroke:#336791,stroke-width:2px
-    linkStyle 14 stroke:#d97706,stroke-width:2px
+    linkStyle 14 stroke:#336791,stroke-width:2px
     linkStyle 15 stroke:#d97706,stroke-width:2px
+    linkStyle 16 stroke:#d97706,stroke-width:2px
 ```
 
 O fluxo de deploy e a infraestrutura funcionam assim:

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -124,38 +124,39 @@ Cada VM precisa de um token de registro gerado no repositório correspondente ao
 
 ## Instalação (`siscan-server-setup.sh`)
 
-O script executa **uma única vez** de forma interativa em cada VM. O flag `--product` seleciona qual aplicação será instalada. Em uma infraestrutura com 3 VMs, execute o script uma vez em cada VM com o produto correspondente.
+O script `siscan-server-setup.sh` é o ponto de entrada para instalar o siscan-rpa e/ou o siscan-dashboard em servidores Ubuntu. Ele é executado **uma única vez** de forma interativa em cada VM. O flag `--product` seleciona qual aplicação será instalada naquela VM. O mesmo script e o mesmo repositório do assistente são usados para instalar qualquer um dos dois produtos — a diferença está no argumento passado.
+
+Em uma infraestrutura com 3 VMs (conforme o diagrama de arquitetura acima), o processo de instalação é:
+
+1. **Na VM do RPA (VM 1):** clone o assistente e execute com `--product rpa`. O script configura o compose do RPA, gera a chave de sessão, solicita as credenciais do banco externo e os caminhos de dados, instala o runner do GitHub Actions e registra no repositório `siscan-rpa`.
+2. **Na VM do Dashboard (VM 3):** clone o assistente novamente (ou copie) e execute com `--product dashboard`. O script configura o compose do dashboard (que inclui o Redis), gera a chave de sessão, solicita as credenciais do banco externo, a connection string do banco do RPA para o sync, e o caminho de logs, instala o runner e registra no repositório `siscan-dashboard`.
+3. **A VM do banco de dados (VM 2)** não precisa do assistente — é um PostgreSQL dedicado que deve estar acessível por ambas as VMs antes de executar o script.
+
+Cada VM é independente — não é necessário instalar uma antes da outra. A única dependência é que o PostgreSQL (VM 2) esteja acessível no momento em que os containers subirem pela primeira vez.
+
+### Instalação do siscan-rpa (VM 1)
+
+Na VM dedicada ao RPA, clone o assistente e execute o script com `--product rpa`:
 
 ```bash
 git clone https://github.com/Prisma-Consultoria/assistente-siscan-rpa.git
 cd assistente-siscan-rpa
-
-# VM do RPA:
 bash ./siscan-server-setup.sh --product rpa
-
-# VM do Dashboard:
-bash ./siscan-server-setup.sh --product dashboard
-
-# Sem --product: o script pergunta interativamente.
 ```
 
-A tabela a seguir descreve o que cada produto configura automaticamente.
+O script configura automaticamente:
 
-| Aspecto | `--product rpa` | `--product dashboard` |
-|---|---|---|
-| Compose file | `docker-compose.prd.rpa.yml` | `docker-compose.prd.dashboard.yml` |
-| .env sample | `.env.server-rpa.sample` | `.env.server-dashboard.sample` |
-| Runner label | `producao-rpa` | `producao-dashboard` |
-| Runner name | `<hostname>-siscan-rpa` | `<hostname>-siscan-dashboard` |
-| Diretório da stack | Diretório onde o assistente foi clonado (`COMPOSE_DIR`) | Idem |
-| Repo URL padrão | `Prisma-Consultoria/siscan-rpa` | `Prisma-Consultoria/siscan-dashboard` |
-| Chave de sessão | `SECRET_KEY` (auto-gerada) | `SESSION_SECRET` (auto-gerada) |
-| Variável extra | — | `RPA_DATABASE_URL` (conexão ao banco do RPA) |
-| Diretórios HOST_* | 5 (logs, downloads, consolidated, PDFs, config) | 1 (logs) |
+| Aspecto | Valor |
+|---|---|
+| Compose file | `docker-compose.prd.rpa.yml` |
+| .env sample | `.env.server-rpa.sample` |
+| Runner label | `producao-rpa` |
+| Runner name | `<hostname>-siscan-rpa` |
+| Repo URL padrão | `Prisma-Consultoria/siscan-rpa` |
+| Chave de sessão | `SECRET_KEY` (auto-gerada) |
+| Diretórios HOST_* | 5 (logs, downloads, consolidated, PDFs, config) |
 
-### Respostas esperadas — produto RPA
-
-A tabela a seguir lista as perguntas interativas do script para o produto RPA e os valores esperados.
+Durante a execução, o script solicita interativamente os seguintes valores:
 
 | Fase | Pergunta | Valor esperado |
 |---|---|---|
@@ -171,9 +172,32 @@ A tabela a seguir lista as perguntas interativas do script para o produto RPA e 
 
 > `SECRET_KEY` é gerada automaticamente — não pergunta.
 
-### Respostas esperadas — produto Dashboard
+### Instalação do siscan-dashboard (VM 3)
 
-A tabela a seguir lista as perguntas interativas para o produto dashboard. A principal diferença é a variável `RPA_DATABASE_URL` que permite ao sync conectar no banco do RPA.
+Na VM dedicada ao dashboard, clone o assistente e execute o script com `--product dashboard`:
+
+```bash
+git clone https://github.com/Prisma-Consultoria/assistente-siscan-rpa.git
+cd assistente-siscan-rpa
+bash ./siscan-server-setup.sh --product dashboard
+```
+
+O script configura automaticamente:
+
+| Aspecto | Valor |
+|---|---|
+| Compose file | `docker-compose.prd.dashboard.yml` |
+| .env sample | `.env.server-dashboard.sample` |
+| Runner label | `producao-dashboard` |
+| Runner name | `<hostname>-siscan-dashboard` |
+| Repo URL padrão | `Prisma-Consultoria/siscan-dashboard` |
+| Chave de sessão | `SESSION_SECRET` (auto-gerada) |
+| Diretórios HOST_* | 1 (logs) |
+| Serviço extra | Redis (cache operacional, criado automaticamente pelo compose) |
+
+A principal diferença em relação ao RPA é a variável `RPA_DATABASE_URL`, que permite ao serviço `sync` conectar no banco do RPA para importar os dados de exames. Sem essa variável, o dashboard sobe mas o sync não funciona.
+
+Durante a execução, o script solicita interativamente os seguintes valores:
 
 | Fase | Pergunta | Valor esperado |
 |---|---|---|

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -1,8 +1,8 @@
 # Guia de Deploy — Modo Servidor (Ubuntu Server)
 <a name="deploy-server"></a>
 
-Versão: 2.0
-Data: 2026-03-23
+Versão: 2.1
+Data: 2026-03-24
 
 Deploy em Ubuntu Server com PostgreSQL externo. O deploy de novas versões é automático via GitHub Actions com self-hosted runner. O assistente suporta dois produtos (`rpa` e `dashboard`), cada um instalado em sua própria VM.
 

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -190,40 +190,54 @@ A tabela a seguir lista as perguntas interativas para o produto dashboard. A pri
 
 ## Fases do script
 
-O script percorre 9 fases em sequência. Algumas fases se adaptam ao produto selecionado, conforme indicado.
+O script `siscan-server-setup.sh` executa 10 fases em sequência. Cada fase exibe um banner com o número e o nome da etapa, seguido de verificações e ações. Se alguma fase falhar, o script interrompe com uma mensagem de erro indicando o problema e a ação corretiva. Algumas fases se adaptam ao produto selecionado (`rpa` ou `dashboard`), conforme indicado.
+
+Antes de iniciar as fases, o script exibe um banner com o produto selecionado, o compose file que será usado, o diretório da stack, o diretório do runner e o usuário atual. Essas informações permitem ao operador confirmar visualmente que os parâmetros estão corretos antes de prosseguir.
 
 ### Fase 1 — Verificação de pré-requisitos
 
-Verifica Docker Engine, Docker Compose v2, curl e sudo. O script não prossegue se algum estiver ausente. Comportamento idêntico para ambos os produtos.
+O script verifica se as ferramentas necessárias estão instaladas e acessíveis: Docker Engine (>= 24.x recomendado), Docker Compose v2 (plugin), curl e sudo. Para cada ferramenta encontrada, exibe a versão detectada. Se alguma estiver ausente, o script interrompe com a instrução de instalação.
+
+No caso do Docker, se o daemon não estiver acessível, o script diagnostica a causa provável: serviço inativo (`systemctl`), usuário fora do grupo `docker`, ou socket `/var/run/docker.sock` inexistente. Essa verificação é idêntica para ambos os produtos.
 
 ---
 
 ### Fase 2 — Usuário dedicado para o runner
 
-Se executado como root, cria o usuário `siscan`, adiciona ao grupo `docker` e re-executa o script como esse usuário (propagando o `--product`). Se executado como não-root, confirma o usuário e prossegue.
+O GitHub Actions runner recusa execução como root. Se o script detectar que está rodando como root, ele cria o usuário `siscan` (solicita que o operador defina uma senha), adiciona ao grupo `docker`, transfere a propriedade do diretório do assistente para esse usuário e re-executa o script inteiro como `siscan`, propagando o `--product` selecionado. Se o script já estiver rodando como não-root, apenas confirma o usuário e prossegue.
 
 ---
 
 ### Fase 3 — Estrutura de diretórios da stack
 
-O diretório da stack é o próprio diretório onde o assistente foi clonado (`SCRIPT_DIR`). Os arquivos da stack (compose, `.env`, config) ficam nesse diretório. Não é necessário criar um diretório separado — o script ajusta as permissões do diretório atual para o usuário que executa.
+O diretório da stack é o próprio diretório onde o assistente foi clonado. Os arquivos da stack (compose file, `.env`, diretório `config/`) ficam nesse mesmo local — não é criado um diretório separado. O script verifica se o diretório existe e se o usuário atual é o dono. Se necessário, ajusta as permissões via `sudo chown`.
 
 ---
 
 ### Fase 4 — Arquivos da stack
 
-Copia o compose file e o diretório `config/` para o diretório da stack. O compose file copiado varia conforme o produto selecionado.
+O script verifica se o compose file correspondente ao produto está presente no diretório da stack. Se não estiver, tenta copiar do diretório de origem do script (caso tenham sido distribuídos juntos). Se o arquivo não for encontrado em nenhum dos dois locais, o script interrompe com a instrução para o operador colocar o arquivo manualmente.
 
 | Produto | Compose file |
 |---|---|
 | `rpa` | `docker-compose.prd.rpa.yml` |
 | `dashboard` | `docker-compose.prd.dashboard.yml` |
 
+Além do compose, o script verifica o diretório `config/` e a presença do arquivo `excel_columns_mapping.json` (necessário para o RPA). Se o `config/` não existir, tenta copiar do diretório de origem ou cria vazio com aviso.
+
 ---
 
 ### Fase 5 — Configuração do `.env`
 
-Cria o `.env` a partir do sample correspondente ao produto e solicita interativamente os valores obrigatórios. A tabela a seguir resume as diferenças.
+Esta é a fase interativa principal. O script cria o `.env` a partir do sample correspondente ao produto (`.env.server-rpa.sample` ou `.env.server-dashboard.sample`) e solicita os valores obrigatórios ao operador.
+
+O fluxo de perguntas segue esta ordem:
+
+1. **Chave de sessão** — gerada automaticamente sem intervenção do operador. Para o RPA, gera `SECRET_KEY`; para o dashboard, gera `SESSION_SECRET`. Ambas são chaves hexadecimais de 256 bits produzidas via `openssl rand -hex 32`.
+2. **`DATABASE_HOST`** — o script pergunta o IP ou hostname do PostgreSQL externo. Se o valor atual for `db` (padrão de desenvolvimento), avisa que é inválido para banco externo e solicita correção.
+3. **`DATABASE_PASSWORD`** — o script pergunta a senha do banco. Se detectar a senha padrão `siscan_rpa`, exibe aviso para alteração. A entrada é ocultada (não ecoa no terminal).
+4. **`RPA_DATABASE_URL`** (apenas para o produto dashboard) — o script solicita a connection string completa para o banco do RPA, exibindo o formato e um exemplo. Essa variável é obrigatória para que o `sync_exames` consiga ler os dados do RPA.
+5. **Diretórios `HOST_*`** — o script percorre cada variável de caminho, exibindo o valor atual e uma descrição. Se o valor atual parecer um caminho Windows (letra de drive, barras invertidas, UNC), exibe um aviso e sugere o equivalente Linux. O operador pode manter o valor atual pressionando Enter ou informar um novo caminho.
 
 | Variável | Produto RPA | Produto Dashboard |
 |---|---|---|
@@ -233,19 +247,29 @@ Cria o `.env` a partir do sample correspondente ao produto e solicita interativa
 | `RPA_DATABASE_URL` | — | Pergunta (obrigatório para o sync) |
 | Diretórios `HOST_*` | 5 caminhos | 1 caminho (`HOST_LOG_DIR`) |
 
-O produto é persistido no `.env` via `SISCAN_PRODUCT=rpa` ou `SISCAN_PRODUCT=dashboard`, permitindo que o assistente (`siscan-assistente.sh`) detecte automaticamente qual produto gerenciar.
+Ao final, o produto é persistido no `.env` via `SISCAN_PRODUCT=rpa` ou `SISCAN_PRODUCT=dashboard`, permitindo que o assistente (`siscan-assistente.sh`) detecte automaticamente qual produto gerenciar em operações futuras.
 
 ---
 
 ### Fase 6 — Criação dos diretórios `HOST_*`
 
-Lê os caminhos definidos nas variáveis `HOST_*` do `.env` e executa `mkdir -p` para cada um. O número de diretórios criados varia: 5 para RPA, 1 para dashboard.
+O script lê os caminhos definidos nas variáveis `HOST_*_DIR` do `.env` e executa `mkdir -p` para cada um, criando toda a estrutura de diretórios necessária para os bind mounts dos containers. Para cada diretório criado com sucesso, exibe uma confirmação. Se a criação falhar (por exemplo, por falta de permissão), exibe um aviso — mas não interrompe o script. O número de diretórios criados varia: 5 para RPA (logs, downloads, consolidados, PDFs, config), 1 para dashboard (logs).
 
 ---
 
 ### Fase 7 — GitHub Actions Runner
 
-Baixa, registra e instala o runner como serviço systemd. A label e o nome do runner são definidos pelo produto conforme a tabela a seguir.
+Esta fase instala e registra o GitHub Actions runner que receberá os deploys automáticos via CI/CD. Se o runner já estiver instalado (detecta `config.sh` no diretório do runner), o script apenas verifica o status do serviço systemd e prossegue.
+
+Se o runner não estiver instalado, o fluxo completo é:
+
+1. **Detecta a arquitetura** do servidor (x86_64 ou aarch64) para baixar o binário correto.
+2. **Consulta a versão mais recente** do runner via API do GitHub (`actions/runner/releases/latest`).
+3. **Baixa e extrai** o tarball no diretório `~/actions-runner`.
+4. **Solicita a URL do repositório** — sugere a URL padrão conforme o produto; o operador pode aceitar com Enter ou informar outra.
+5. **Solicita o token de registro** — o operador deve copiar o token gerado na tela de Settings → Actions → Runners → New do repositório correspondente. O token expira em poucos minutos.
+6. **Registra o runner** com a label e o nome definidos pelo produto, usando `--unattended --replace`.
+7. **Instala como serviço systemd** e inicia o serviço. O runner passa a rodar em background e sobrevive a reinicializações do servidor.
 
 | Aspecto | Produto RPA | Produto Dashboard |
 |---|---|---|
@@ -253,31 +277,33 @@ Baixa, registra e instala o runner como serviço systemd. A label e o nome do ru
 | Nome | `<hostname>-siscan-rpa` | `<hostname>-siscan-dashboard` |
 | URL padrão do repo | `Prisma-Consultoria/siscan-rpa` | `Prisma-Consultoria/siscan-dashboard` |
 
-O script sugere a URL padrão — basta pressionar Enter para aceitar. O token de registro deve ser gerado no repositório correspondente (ver [pré-requisitos](#token-de-registro-do-runner)).
-
 ---
 
 ### Fase 8 — Persistir `COMPOSE_DIR` no ambiente do runner
 
-O runner roda como serviço systemd e não carrega `~/.bashrc` nem `/etc/environment`. O script grava `COMPOSE_DIR` (diretório do assistente) no `~/actions-runner/.env` — o único mecanismo para injetar variáveis nos jobs do GitHub Actions. Também persiste em `/etc/environment` para sessões interativas.
+O runner roda como serviço systemd e não carrega `~/.bashrc` nem `/etc/environment`. Para que os workflows de CD consigam localizar o compose file e o `.env` no servidor, o script grava a variável `COMPOSE_DIR` (diretório do assistente) em dois locais:
 
-Ambos os workflows de CD (siscan-rpa e siscan-dashboard) usam `${COMPOSE_DIR}` para localizar o compose file e o `.env` no servidor.
+1. **`~/actions-runner/.env`** — é o único mecanismo para injetar variáveis de ambiente nos jobs executados pelo runner. Ambos os workflows de CD (siscan-rpa e siscan-dashboard) usam `${COMPOSE_DIR}` para navegar até o diretório correto antes de executar `docker compose`.
+2. **`/etc/environment`** — disponibiliza a variável para sessões interativas (SSH), permitindo que o operador use `cd $COMPOSE_DIR` para acessar rapidamente o diretório da stack.
 
 ---
 
 ### Fase 9 — Permissões Docker
 
-Verifica se o usuário atual pertence ao grupo `docker` e adiciona se necessário. Comportamento idêntico para ambos os produtos.
+O script verifica se o usuário atual pertence ao grupo `docker`. Se não pertencer, executa `sudo usermod -aG docker` e avisa que é necessário logout/login para que a mudança tenha efeito na sessão do terminal. O serviço do runner, por reiniciar via systemd, já terá o grupo automaticamente. Comportamento idêntico para ambos os produtos.
 
 ---
 
 ### Fase 10 — Resumo e próximos passos
 
-Exibe o que foi configurado (produto, diretório, compose, runner) e os próximos passos:
+O script exibe um resumo completo do que foi configurado: produto, diretório da stack, compose file, `.env`, diretório do runner e label. Em seguida, lista os próximos passos que o operador deve executar:
 
-1. Revisar o `.env` no diretório da stack.
-2. Confirmar que o runner aparece como **Idle** em GitHub → Settings → Actions → Runners.
-3. O próximo merge para `main` no repositório correspondente acionará o deploy automaticamente.
+1. Revisar o `.env` no diretório da stack para confirmar que todos os valores estão corretos.
+2. Confirmar que o runner aparece como **Idle** em GitHub → Settings → Actions → Runners do repositório correspondente.
+3. Verificar o status do serviço do runner via `sudo ~/actions-runner/svc.sh status`.
+4. O próximo merge para `main` no repositório correspondente acionará o deploy automaticamente. Para acionar manualmente, usar Actions → CD → Run workflow.
+5. Acompanhar os logs do runner via `journalctl -u actions.runner.*.service -f`.
+6. Acompanhar os logs da stack após o primeiro deploy via `docker compose -f <compose-file> logs -f`.
 
 ---
 

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -10,7 +10,9 @@ Deploy em Ubuntu Server com PostgreSQL externo. O deploy de novas versões é au
 
 ## Arquitetura — infraestrutura com 3 VMs
 
-O diagrama a seguir ilustra a topologia de produção com 3 VMs: uma para o RPA, uma para o banco de dados e uma para o dashboard. Cada VM de aplicação tem seu próprio runner GitHub Actions que recebe deploys automáticos.
+O sistema SISCAN opera com dois produtos distintos: o **siscan-rpa**, responsável pela coleta automatizada de dados do portal SISCAN via navegador, e o **siscan-dashboard**, um painel analítico que exibe indicadores de câncer de mama a partir dos dados coletados. Em produção, esses produtos rodam em VMs separadas, conectados por um banco de dados PostgreSQL central.
+
+O diagrama a seguir ilustra a topologia de produção com 3 VMs e o fluxo de deploy automatizado.
 
 ```mermaid
 flowchart TD
@@ -66,12 +68,14 @@ flowchart TD
     linkStyle 15 stroke:#d97706,stroke-width:2px
 ```
 
-Pontos relevantes do diagrama:
+O fluxo de deploy e a infraestrutura funcionam assim:
 
-- Cada VM de aplicação recebe deploys de forma independente — o merge no siscan-rpa não afeta o dashboard e vice-versa.
-- O serviço `sync` no dashboard lê do banco `siscan_rpa` e escreve no banco `siscan_dashboard`, mantendo a tabela analítica atualizada a cada 30 minutos.
-- O banco de dados (VM 2) não tem runner nem assistente — é um PostgreSQL dedicado que atende ambas as aplicações.
-- O Redis roda na VM 3 como container local da stack do dashboard, servindo como cache operacional e armazenamento dos payloads pré-calculados.
+1. Quando um desenvolvedor faz merge na branch `main` de qualquer um dos repositórios (siscan-rpa ou siscan-dashboard), o GitHub Actions inicia automaticamente o pipeline de CI/CD. O pipeline compila a imagem Docker do produto alterado e publica no GitHub Container Registry (GHCR).
+2. Em seguida, o pipeline dispara um job de deploy direcionado ao runner self-hosted da VM correspondente. Cada VM de aplicação possui seu próprio runner registrado no GitHub — o merge no siscan-rpa aciona apenas o runner da VM 1, e o merge no siscan-dashboard aciona apenas o runner da VM 3. Os deploys são independentes.
+3. A **VM 1 (siscan-rpa)** hospeda o produto de coleta automatizada. O container `app` (porta 5001) oferece o painel administrativo do RPA, e o `rpa-scheduler` executa as coletas no portal SISCAN em intervalos configuráveis. Ambos conectam ao PostgreSQL na VM 2.
+4. A **VM 2 (Banco de dados)** é um PostgreSQL dedicado que hospeda dois bancos: `siscan_rpa` (dados da coleta) e `siscan_dashboard` (dados analíticos). Essa VM não tem runner nem assistente — é gerenciada separadamente.
+5. A **VM 3 (siscan-dashboard)** hospeda o painel analítico. O container `app` (porta 5000) serve a interface web via Gunicorn, e o `sync` importa dados do banco do RPA para o banco do dashboard a cada 30 minutos. O Redis roda como container local nessa mesma VM, servindo como cache operacional compartilhado entre os workers do Gunicorn e como armazenamento dos payloads pré-calculados que aceleram a carga inicial do dashboard.
+6. As setas em <span style="color:#336791">**azul**</span> representam conexões com o PostgreSQL (TCP 5432). As setas em <span style="color:#d97706">**âmbar**</span> representam conexões com o Redis (cache local na VM 3).
 
 ---
 


### PR DESCRIPTION
## Summary

- Adiciona serviço Redis e variáveis (`REDIS_HOST`, `REDIS_PORT`, `CACHE_TIMEOUT`, `CACHE_KEY_PREFIX`) no `docker-compose.prd.dashboard.yml` com `depends_on` nos serviços migrate, app e sync
- Atualiza `.env.server-dashboard.sample`, `.env.host.sample` e `.env.help.json` com as novas variáveis
- Adiciona Redis nos diagramas de arquitetura do `DEPLOY_SERVER.md` e `DEPLOY_HOST.md` com cores diferenciadas (azul para PostgreSQL, âmbar para Redis)
- Enriquece explicação dos diagramas para leitores sem contexto (o que é siscan-rpa, siscan-dashboard, o papel de cada VM/container)
- Detalha as 10 fases do `siscan-server-setup.sh` com descrição completa do que cada fase faz
- Separa instalação do siscan-rpa e siscan-dashboard em subseções independentes
- Padroniza nomenclatura de "Produto RPA/Dashboard" para "siscan-rpa/siscan-dashboard"
- Atualiza versões dos docs para 2.1 / 2026-03-24

## Test plan

- [ ] Verificar renderização dos diagramas Mermaid no GitHub (cores e linkStyle)
- [ ] Confirmar que `docker compose -f docker-compose.prd.dashboard.yml config` resolve sem erros
- [ ] Validar que o `.env.server-dashboard.sample` contém todas as variáveis necessárias

🤖 Generated with [Claude Code](https://claude.com/claude-code)