### PR TITLE
refs #26 atualiza CHECKLISTS e TROUBLESHOOTING com Redis e --check

### DIFF
--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -1,8 +1,8 @@
 # Checklists Operacionais — Assistente SISCAN
 <a name="checklists"></a>
 
-Versão: 4.0
-Data: 2026-03-23
+Versão: 4.1
+Data: 2026-03-24
 
 Checklists para os três modos de deploy: HOST (PC local, produto `full`), Servidor RPA (produto `rpa`) e Servidor Dashboard (produto `dashboard`).
 
@@ -40,8 +40,9 @@ Este checklist se aplica a qualquer modo de deploy, independentemente do produto
 
 ### Após instalação (Opção 2 do menu)
 
-- [ ] 7 containers em execução: `docker compose -f docker-compose.prd.host.yml ps`.
+- [ ] 8 containers em execução: `docker compose -f docker-compose.prd.host.yml ps` (inclui `redis`).
 - [ ] Serviços healthy: `app`, `dashboard-app`.
+- [ ] Redis operacional: `docker compose -f docker-compose.prd.host.yml exec redis redis-cli ping` → `PONG`.
 - [ ] RPA acessível: `http://localhost:5001/health` → `"schema_status":"current"`.
 - [ ] Dashboard acessível: `http://localhost:5000/health` → `"schema_status":"current"`.
 - [ ] Credenciais SISCAN cadastradas: `http://localhost:5001/admin/siscan-credentials`.
@@ -50,7 +51,7 @@ Este checklist se aplica a qualquer modo de deploy, independentemente do produto
 
 ---
 
-## Modo Servidor — produto `rpa` (VM do RPA)
+## Modo Servidor — siscan-rpa (VM do RPA)
 
 ### Antes do primeiro deploy
 
@@ -71,9 +72,15 @@ Este checklist se aplica a qualquer modo de deploy, independentemente do produto
 - [ ] Credenciais SISCAN cadastradas em `/admin/siscan-credentials`.
 - [ ] Primeira coleta manual executada com sucesso.
 
+### Verificação de consistência (instalação existente)
+
+```bash
+bash ./siscan-server-setup.sh --product rpa --check
+```
+
 ---
 
-## Modo Servidor — produto `dashboard` (VM do Dashboard)
+## Modo Servidor — siscan-dashboard (VM do Dashboard)
 
 ### Antes do primeiro deploy
 
@@ -90,11 +97,18 @@ Este checklist se aplica a qualquer modo de deploy, independentemente do produto
 
 ### Após configuração
 
-- [ ] Containers em execução: `docker compose -f docker-compose.prd.dashboard.yml ps` → `app` e `sync` com status `Up` / `healthy`.
+- [ ] Containers em execução: `docker compose -f docker-compose.prd.dashboard.yml ps` → `redis`, `app` e `sync` com status `Up` / `healthy`.
+- [ ] Redis operacional: `docker compose -f docker-compose.prd.dashboard.yml exec redis redis-cli ping` → `PONG`.
 - [ ] Health: `http://<IP>:5000/health` → `"schema_status":"current"`.
 - [ ] Runner online: GitHub → `siscan-dashboard` → Settings → Actions → Runners → status `Idle`.
 - [ ] Login funcional: admin / senha definida em `ADMIN_PASSWORD`.
 - [ ] Sync executado: dados do RPA visíveis no dashboard.
+
+### Verificação de consistência (instalação existente)
+
+```bash
+bash ./siscan-server-setup.sh --product dashboard --check
+```
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,8 +1,8 @@
 # Guia de Troubleshooting — Assistente SISCAN
 <a name="troubleshooting"></a>
 
-Versão: 4.0
-Data: 2026-03-23
+Versão: 4.1
+Data: 2026-03-24
 
 Os problemas estão organizados em três grupos:
 - **Problemas comuns** — ocorrem em qualquer modo (HOST ou Servidor).
@@ -410,9 +410,9 @@ grep -v '^#' /opt/siscan-rpa/.env | cut -d= -f1 > /tmp/env-keys.txt
 
 ---
 
-## Problemas específicos do Dashboard
+## Problemas específicos do siscan-dashboard
 
-Esta seção cobre problemas que ocorrem apenas com o produto `dashboard` (modo servidor ou HOST).
+Esta seção cobre problemas que ocorrem apenas com o siscan-dashboard (modo servidor ou HOST).
 
 ### Sync retorna "0 registros" mas o banco do RPA tem dados
 
@@ -438,6 +438,37 @@ e = create_engine(os.environ['RPA_DATABASE_URL'])
 with e.connect() as c: print(c.execute(text('SELECT count(*) FROM exam_records')).scalar())
 "
 ```
+
+### Redis não responde ou container não sobe
+
+Sintoma: container `redis` não aparece no `docker compose ps`, ou o dashboard apresenta lentidão na carga inicial (cache não está funcionando).
+
+| Passo | O que Fazer | Como Fazer |
+|---|---|---|
+| 1 | Verificar se o container Redis existe | `docker compose -f docker-compose.prd.dashboard.yml ps redis` |
+| 2 | Verificar se o Redis responde | `docker compose -f docker-compose.prd.dashboard.yml exec redis redis-cli ping` — esperado: `PONG` |
+| 3 | Verificar variáveis no `.env` | `grep REDIS .env` — deve ter `REDIS_HOST=redis` e `REDIS_PORT=6379` |
+| 4 | Verificar se o compose inclui o serviço Redis | `grep -A3 'redis:' docker-compose.prd.dashboard.yml` — deve mostrar `image: redis:7-alpine` |
+| 5 | Atualizar compose se Redis ausente | O workflow de CD atualiza automaticamente. Para forçar: `curl -fsSL https://raw.githubusercontent.com/Prisma-Consultoria/assistente-siscan-rpa/main/docker-compose.prd.dashboard.yml -o docker-compose.prd.dashboard.yml` |
+| 6 | Recriar a stack | `docker compose -f docker-compose.prd.dashboard.yml down && docker compose -f docker-compose.prd.dashboard.yml up -d --wait` |
+
+> O Redis é um serviço local do compose — não precisa de instalação separada. Se o compose estiver atualizado e o `.env` tiver as variáveis `REDIS_HOST` e `REDIS_PORT`, o container sobe automaticamente.
+
+---
+
+### Variáveis faltantes no .env após atualização do assistente
+
+Sintoma: novos recursos não funcionam após atualizar o assistente (ex.: Redis não ativo porque `REDIS_HOST` não está no `.env`).
+
+| Passo | O que Fazer | Como Fazer |
+|---|---|---|
+| 1 | Executar verificação de consistência | `bash ./siscan-server-setup.sh --product dashboard --check` |
+| 2 | O script lista variáveis faltantes | Aceitar a adição automática com valores default do sample |
+| 3 | Reiniciar a stack | `docker compose -f docker-compose.prd.dashboard.yml down && docker compose -f docker-compose.prd.dashboard.yml up -d --wait` |
+
+O `--check` compara o `.env` atual com o `.env.server-dashboard.sample` e identifica variáveis que existem no sample mas não no `.env`. Funciona também para o siscan-rpa com `--product rpa --check`.
+
+---
 
 ### Dashboard mostra "schema_status: outdated"
 


### PR DESCRIPTION
## Summary

- `CHECKLISTS.md`: 8 containers (inclui Redis), verificação Redis no HOST e Servidor, seção `--check` para ambos os produtos, nomenclatura siscan-rpa/siscan-dashboard
- `TROUBLESHOOTING.md`: problemas de Redis e variáveis faltantes com `--check`, nomenclatura atualizada

## Test plan

- [ ] Verificar que os checklists refletem a stack atual (8 containers no HOST, redis no servidor)
- [ ] Verificar que os comandos `--check` documentados funcionam

🤖 Generated with [Claude Code](https://claude.com/claude-code)