### PR TITLE
docs(DEPLOY_SERVER): remover passo chmod e clarificar geração do token de runner

### DIFF
--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -499,16 +499,9 @@ ls -la scripts/data/products.json scripts/data/network-endpoints.json
 
 **Esperado:** 9 arquivos `check-*.sh` em `scripts/deploy_server/`, mais `_common.sh`, os 3 scripts no root e os 2 JSON em `scripts/data/`.
 
-#### Passo 3 — Garantir bit executável
+> Os scripts já vêm com bit `+x` no índice do git (`100755`), então um `git pull` em clone normal preserva a permissão e não é preciso `chmod +x` na VM. Se em algum caso isolado a permissão se perder (ex.: cópia via `rsync` sem `-p`, download como zip), rode `chmod +x siscan-server-doctor.sh siscan-runner-recover.sh scripts/deploy_server/check-*.sh` antes do Passo 3.
 
-```bash
-chmod +x siscan-server-doctor.sh siscan-runner-recover.sh
-chmod +x scripts/deploy_server/check-*.sh
-```
-
-Necessário porque alguns checkouts (especialmente download em zip ou git mais antigo) não preservam o bit `+x`.
-
-#### Passo 4 — Primeira foto da saúde da VM
+#### Passo 3 — Primeira foto da saúde da VM
 
 ```bash
 bash siscan-server-doctor.sh
@@ -516,9 +509,9 @@ bash siscan-server-doctor.sh
 
 **Esperado:** resumo final do tipo `X/9 specialists OK · Y com FAIL`. É **normal** ver FAILs informativos nessa primeira execução (ex.: `check-runner` se runner está auto-removido, `check-stack` se a stack não está rodando). O que importa é entender **quais** dimensões falharam — cada specialist exibe a ação corretiva embaixo do bloco dele.
 
-#### Passo 5 — Se `check-runner` ou `check-stack` apontaram problema → recuperar runner
+#### Passo 4 — Se `check-runner` ou `check-stack` apontaram problema → recuperar runner
 
-Se o passo 4 mostrou problema em `check-runner` (auto-removido após 14 dias offline, ou regra dos 30 dias), rode:
+Se o passo 3 mostrou problema em `check-runner` (auto-removido após 14 dias offline, ou regra dos 30 dias), rode:
 
 ```bash
 bash siscan-runner-recover.sh
@@ -528,11 +521,13 @@ O script:
 - Detecta o produto via `.env` (`siscan-rpa` ou `siscan-dashboard`)
 - Faz pré-flight com o doctor (network + deps + docker + permissions)
 - Diagnostica o cenário (auto-removed ou stale 30d ou OK)
-- **Se for auto-removed**: pede token novo (gere em `https://github.com/Prisma-Consultoria/<repo>/settings/actions/runners/new`) e refaz o registro
+- **Se for auto-removed**: pede um token novo de registro do runner e refaz o registro
 - **Se for stale 30d**: roda `run.sh --check` (não precisa token)
 - Valida ao fim chamando `check-runner` novamente
 
-#### Passo 6 — Validação final completa
+> **Token de registro do runner:** quem gera é um administrador do repositório do produto correspondente (`Prisma-Consultoria/siscan-rpa` ou `Prisma-Consultoria/siscan-dashboard`) em `Settings → Actions → Runners → New self-hosted runner`. O token expira em ~1h, então combine com o admin que ele gere **no momento** em que você for executar este passo, e cole o valor quando o script perguntar. O operador da VM não precisa de permissão administrativa no repo.
+
+#### Passo 5 — Validação final completa
 
 ```bash
 bash siscan-server-doctor.sh
@@ -546,7 +541,7 @@ sudo journalctl -u 'actions.runner.*' -f | grep -E "Listening|Running|error"
 
 Ou aguarde o próximo deploy automático (workflow CD da branch `main` do produto correspondente) — depois disso a stack sobe e `check-stack` passa também.
 
-#### Passo 7 (opcional) — Inventário do que o assistente entrega agora
+#### Passo 6 (opcional) — Inventário do que o assistente entrega agora
 
 ```bash
 bash siscan-server-doctor.sh --list


### PR DESCRIPTION
## Sumário

Ajusta o playbook \"Primeira atualização para a versão com diagnóstico amplo\" em `docs/DEPLOY_SERVER.md` para refletir a realidade operacional:

- **Remove Passo 3 (chmod +x)**: os scripts já estão no índice do git em modo `100755`, então `git pull` em clone normal já entrega executável. O passo virou ruído na maioria dos casos.
- **Renumera Passos 4→3, 5→4, 6→5, 7→6** e atualiza todas as referências cruzadas internas.
- **Substitui o passo por callout informativo** explicando quando o chmod ainda é necessário (`rsync` sem `-p`, download como zip) — útil mas não bloqueante.
- **Reescreve o trecho sobre o token de registro do runner**: agora deixa claro que **um administrador do repo `Prisma-Consultoria/siscan-rpa` ou `siscan-dashboard` é quem gera o token**, não operador da VM. Adiciona callout dedicado explicando que o token expira em ~1h e que a geração deve ser coordenada com a execução do passo.

## Motivação

Antes de mandar o playbook pra o operador atualizar a <HOST-DASHBOARD>, dois ajustes ficaram evidentes:

1. O chmod era cargo-cult — bit `+x` já vai no `git pull`, confirmei com `git ls-files --stage` (todos os scripts retornam `100755`). Não precisamos pedir pra ela fazer.
2. A linha original \"gere em `.../runners/new`\" sugeria que o operador da VM tinha que gerar o token, mas na prática isso requer permissão admin no repo do produto — quem tem essa permissão é o time da Prisma-Consultoria, não operador da VM no parceiro.

## Verificação

```bash
# Confirmar que bits estão no índice
git ls-files --stage siscan-server-doctor.sh siscan-runner-recover.sh scripts/deploy_server/check-*.sh
# Esperado: todos retornam mode 100755

# Confirmar que nenhuma referência cruzada quebrou
grep -n \"Passo [0-9]\\|passo [0-9]\" docs/DEPLOY_SERVER.md
# Esperado: Passos 1-6 em ordem, sem buracos
```

## Test plan

- [x] Verificar que diff só toca a seção \"Playbook — primeira atualização\"
- [x] Renumeração consistente (1, 2, 3, 4, 5, 6) sem buracos
- [x] Referência cruzada \"Se o passo 3 mostrou problema\" alinhada com nova numeração do passo do doctor
- [x] Callout do token explicita quem é o admin (Prisma-Consultoria) vs quem é o operador da VM
- [ ] o operador segue o playbook atualizado na <HOST-DASHBOARD> (validação operacional, fora do escopo do PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
