### PR TITLE
docs(runner-recover): clarificar SISCAN_PRODUCT + flag --product no playbook

### DIFF
--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -511,14 +511,22 @@ bash siscan-server-doctor.sh
 
 #### Passo 4 — Se `check-runner` ou `check-stack` apontaram problema → recuperar runner
 
-Se o passo 3 mostrou problema em `check-runner` (auto-removido após 14 dias offline, ou regra dos 30 dias), rode:
+Se o passo 3 mostrou problema em `check-runner` (auto-removido após 14 dias offline, ou regra dos 30 dias), rode (a partir do `$COMPOSE_DIR`, que tem o `.env` com `SISCAN_PRODUCT` configurado):
 
 ```bash
 bash siscan-runner-recover.sh
 ```
 
+> **Caso `SISCAN_PRODUCT` não esteja no `.env`** (cenário de testes locais ou recuperação em diretório sem `.env`), o script aborta com `ERRO: SISCAN_PRODUCT não definido`. Nesse caso, passe o produto explicitamente — um destes três valores conforme o caso da VM:
+>
+> ```bash
+> bash siscan-runner-recover.sh --product rpa         # VM do RPA
+> bash siscan-runner-recover.sh --product dashboard   # VM do Dashboard
+> bash siscan-runner-recover.sh --product full        # VM que hospeda os dois
+> ```
+
 O script:
-- Detecta o produto via `.env` (`siscan-rpa` ou `siscan-dashboard`)
+- Detecta o produto via `.env` (ou aceita `--product` explícito quando `.env` não estiver disponível)
 - Faz pré-flight com o doctor (network + deps + docker + permissions)
 - Diagnostica o cenário (auto-removed ou stale 30d ou OK)
 - **Se for auto-removed**: pede um token novo de registro do runner e refaz o registro

--- a/docs/siscan-server-doctor/scripts/siscan-runner-recover.md
+++ b/docs/siscan-server-doctor/scripts/siscan-runner-recover.md
@@ -42,13 +42,17 @@ bash siscan-runner-recover.sh --help
 Quando você roda sem `--product`, o script tenta inferir o produto do `.env` da VM. **Não há "magia": é grep simples sobre arquivo de dados.**
 
 ```bash
-ENV_FILE="${COMPOSE_DIR}/.env"   # COMPOSE_DIR cai pra $(pwd) se não exportado
+# COMPOSE_DIR cai pra $(pwd) se não exportado;
+# --env-file VALOR no CLI sobrescreve este default (ver --help do script).
+ENV_FILE="${COMPOSE_DIR}/.env"
 
 _read_env_var() {
-    grep -E "^SISCAN_PRODUCT=" "$ENV_FILE" 2>/dev/null \
-        | tail -1 \                            # última linha vence (override)
-        | cut -d= -f2- \                       # tudo após o primeiro '='
-        | sed 's/^["'\'']\(.*\)["'\'']$/\1/'   # remove aspas envolventes se houver
+    # Pipeline em uma linha — copy-paste seguro (sem trailing spaces após \).
+    # 1. grep   → linhas começando com 'SISCAN_PRODUCT='
+    # 2. tail   → última atribuição vence (override permitido)
+    # 3. cut    → pega tudo após o primeiro '='
+    # 4. sed    → remove aspas envolventes ("..." ou '...')
+    grep -E "^SISCAN_PRODUCT=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- | sed 's/^["'\'']\(.*\)["'\'']$/\1/'
 }
 ```
 

--- a/docs/siscan-server-doctor/scripts/siscan-runner-recover.md
+++ b/docs/siscan-server-doctor/scripts/siscan-runner-recover.md
@@ -22,12 +22,20 @@ Resolução: `sudo -u siscan ./run.sh --check` (**não** precisa token).
 ## Sinopse
 
 ```bash
-bash siscan-runner-recover.sh                       # detecta produto via .env
-bash siscan-runner-recover.sh --product rpa         # explícito
+bash siscan-runner-recover.sh                       # detecta produto via $COMPOSE_DIR/.env (SISCAN_PRODUCT)
+bash siscan-runner-recover.sh --product rpa         # explícito (sem .env ou .env sem SISCAN_PRODUCT)
 bash siscan-runner-recover.sh --product dashboard
+bash siscan-runner-recover.sh --product full        # VM que hospeda RPA + Dashboard
 bash siscan-runner-recover.sh --skip-doctor         # pula pré-flight (debug)
 bash siscan-runner-recover.sh --help
 ```
+
+> **Pré-requisito**: o script precisa saber o produto antes de qualquer ação. Resolução em ordem:
+> 1. `--product VALOR` explícito vence sempre.
+> 2. Senão, lê `SISCAN_PRODUCT` de `$COMPOSE_DIR/.env`.
+> 3. Se nenhum dos dois resolveu, aborta com `ERRO: SISCAN_PRODUCT não definido. Use --product rpa|dashboard|full ou preencha .env.`
+>
+> Operacionalmente isso significa que **na VM você pode rodar sem flag** (o `.env` já vem do `siscan-server-setup.sh`); fora da VM (ex.: testes locais, debug em dev box) você usa `--product`.
 
 ## Como o script decide o que fazer
 

--- a/docs/siscan-server-doctor/scripts/siscan-runner-recover.md
+++ b/docs/siscan-server-doctor/scripts/siscan-runner-recover.md
@@ -22,20 +22,23 @@ Resolução: `sudo -u siscan ./run.sh --check` (**não** precisa token).
 ## Sinopse
 
 ```bash
-bash siscan-runner-recover.sh                       # detecta produto via $COMPOSE_DIR/.env (SISCAN_PRODUCT)
-bash siscan-runner-recover.sh --product rpa         # explícito (sem .env ou .env sem SISCAN_PRODUCT)
+bash siscan-runner-recover.sh                              # detecta produto via $COMPOSE_DIR/.env (SISCAN_PRODUCT)
+bash siscan-runner-recover.sh --product rpa                # explícito (sem .env ou .env sem SISCAN_PRODUCT)
 bash siscan-runner-recover.sh --product dashboard
-bash siscan-runner-recover.sh --product full        # VM que hospeda RPA + Dashboard
-bash siscan-runner-recover.sh --skip-doctor         # pula pré-flight (debug)
+bash siscan-runner-recover.sh --product full               # VM que hospeda RPA + Dashboard
+bash siscan-runner-recover.sh --env-file /path/to/.env     # apontar pra um .env em outro caminho
+bash siscan-runner-recover.sh --skip-doctor                # pula pré-flight (debug)
 bash siscan-runner-recover.sh --help
 ```
 
 > **Pré-requisito**: o script precisa saber o produto antes de qualquer ação. Resolução em ordem:
 > 1. `--product VALOR` explícito vence sempre.
-> 2. Senão, lê `SISCAN_PRODUCT` de `$COMPOSE_DIR/.env`.
+> 2. Senão, lê `SISCAN_PRODUCT` do **`ENV_FILE` efetivo**:
+>    - default: `$COMPOSE_DIR/.env` (ou `$PWD/.env` se `COMPOSE_DIR` não estiver exportada)
+>    - override: `--env-file /caminho/para/.env` na CLI
 > 3. Se nenhum dos dois resolveu, aborta com `ERRO: SISCAN_PRODUCT não definido. Use --product rpa|dashboard|full ou preencha .env.`
 >
-> Operacionalmente isso significa que **na VM você pode rodar sem flag** (o `.env` já vem do `siscan-server-setup.sh`); fora da VM (ex.: testes locais, debug em dev box) você usa `--product`.
+> Operacionalmente isso significa que **na VM você pode rodar sem flag** (o `.env` já vem do `siscan-server-setup.sh`); fora da VM (ex.: testes locais, debug em dev box) você usa `--product` ou `--env-file` apontando pra um `.env` válido.
 
 ## Detecção de SISCAN_PRODUCT a partir do `.env`
 
@@ -65,11 +68,11 @@ Características desse mecanismo:
 
 **Pré-requisitos pra detecção via `.env` funcionar:**
 
-1. `$COMPOSE_DIR` aponta pra um diretório acessível (ou está rodando dentro dele — `$(pwd)` é o fallback).
-2. Existe um arquivo `$COMPOSE_DIR/.env` legível pelo usuário corrente.
+1. `ENV_FILE` aponta pra um caminho legível. Default = `$COMPOSE_DIR/.env` (ou `$PWD/.env` se `COMPOSE_DIR` não estiver exportada); pode ser sobrescrito por `--env-file VALOR` na CLI.
+2. O arquivo apontado por `ENV_FILE` existe e é legível pelo usuário corrente.
 3. Esse arquivo tem uma linha `SISCAN_PRODUCT=<rpa|dashboard|full>`.
 
-Se qualquer um dos 3 falhar, a saída é o erro documentado em "Pré-requisito" acima — solução: passar `--product VALOR` na CLI ou ajustar o `.env`.
+Se qualquer um dos 3 falhar, a saída é o erro documentado em "Pré-requisito" acima — soluções: passar `--product VALOR` na CLI, `--env-file /caminho/.env` apontando pra um `.env` válido em outro lugar, ou ajustar o `.env` do default.
 
 ## Como o script decide o que fazer
 

--- a/docs/siscan-server-doctor/scripts/siscan-runner-recover.md
+++ b/docs/siscan-server-doctor/scripts/siscan-runner-recover.md
@@ -37,6 +37,36 @@ bash siscan-runner-recover.sh --help
 >
 > Operacionalmente isso significa que **na VM você pode rodar sem flag** (o `.env` já vem do `siscan-server-setup.sh`); fora da VM (ex.: testes locais, debug em dev box) você usa `--product`.
 
+## Detecção de SISCAN_PRODUCT a partir do `.env`
+
+Quando você roda sem `--product`, o script tenta inferir o produto do `.env` da VM. **Não há "magia": é grep simples sobre arquivo de dados.**
+
+```bash
+ENV_FILE="${COMPOSE_DIR}/.env"   # COMPOSE_DIR cai pra $(pwd) se não exportado
+
+_read_env_var() {
+    grep -E "^SISCAN_PRODUCT=" "$ENV_FILE" 2>/dev/null \
+        | tail -1 \                            # última linha vence (override)
+        | cut -d= -f2- \                       # tudo após o primeiro '='
+        | sed 's/^["'\'']\(.*\)["'\'']$/\1/'   # remove aspas envolventes se houver
+}
+```
+
+Características desse mecanismo:
+
+- **Lê como dados, não como código**: NÃO usa `source .env` nem `eval`. Isso evita que chars especiais no valor (`$`, `` ` ``, aspas mal-fechadas) sejam interpretados como bash — proteção contra command injection.
+- **Última atribuição vence** (`tail -1`): se o `.env` tiver `SISCAN_PRODUCT=` duas vezes, prevalece a de baixo (consistente com o comportamento de `docker compose` e `dotenv`).
+- **Aspas envolventes são strippadas**: aceita `SISCAN_PRODUCT=rpa`, `SISCAN_PRODUCT="rpa"` ou `SISCAN_PRODUCT='rpa'` indistintamente.
+- **Mesmo padrão dos demais specialists**: `check-env`, `check-permissions`, `check-db`, `check-runner` usam função idêntica — qualquer mudança aqui precisa ser propagada (ou extraída pra `_common.sh`).
+
+**Pré-requisitos pra detecção via `.env` funcionar:**
+
+1. `$COMPOSE_DIR` aponta pra um diretório acessível (ou está rodando dentro dele — `$(pwd)` é o fallback).
+2. Existe um arquivo `$COMPOSE_DIR/.env` legível pelo usuário corrente.
+3. Esse arquivo tem uma linha `SISCAN_PRODUCT=<rpa|dashboard|full>`.
+
+Se qualquer um dos 3 falhar, a saída é o erro documentado em "Pré-requisito" acima — solução: passar `--product VALOR` na CLI ou ajustar o `.env`.
+
 ## Como o script decide o que fazer
 
 Diagnóstico em 4 passos:


### PR DESCRIPTION
## Sumário

Quando o operador roda \`bash siscan-runner-recover.sh\` fora de um \`\$COMPOSE_DIR\` configurado (dev box local, debug em VM diferente, diretório sem \`.env\`), o script aborta com:

```
ERRO: SISCAN_PRODUCT não definido. Use --product rpa|dashboard|full ou preencha .env.
```

A doc do playbook em \`DEPLOY_SERVER.md\` não mencionava a flag \`--product\` — operador pegava o erro sem saída clara além de ler o \`--help\`.

## Caso real

Rodei o recover em dev box pra validar a sequência. Erro imediato:
```
jailton@hpz2g5:~/workspace/prisma_roche/assistente-siscan-rpa$ bash siscan-runner-recover.sh
══════════════════════════════════════════════════
  1/6 — Detecção do produto e validação do manifesto
══════════════════════════════════════════════════

ERRO: SISCAN_PRODUCT não definido. Use --product rpa|dashboard|full ou preencha .env.
```

A mensagem do script é boa, mas o playbook (que é o entry point) deveria preparar pra isso.

## Mudanças

### \`docs/DEPLOY_SERVER.md\` — Passo 4

- Acrescenta no parágrafo introdutório \"a partir do \`\$COMPOSE_DIR\`, que tem o \`.env\` com \`SISCAN_PRODUCT\` configurado\" — esclarece **por que** a versão sem flag funciona na VM
- Callout dedicado mostrando as 3 variantes (\`--product rpa|dashboard|full\`) com a quem cada uma se aplica
- Atualiza descrição do \"o script:\" pra mencionar que \`--product\` é alternativa ao \`.env\`

### \`docs/siscan-server-doctor/scripts/siscan-runner-recover.md\` — Sinopse

- Adiciona \`--product full\` (estava faltando — só tinha rpa e dashboard)
- Esclarece os comentários inline da sinopse
- Novo callout \"Pré-requisito\" com a ordem de resolução do produto:
  1. \`--product\` explícito vence sempre
  2. Senão, lê \`SISCAN_PRODUCT\` de \`\$COMPOSE_DIR/.env\`
  3. Se nenhum resolveu, aborta com a mensagem documentada acima
- Regra operacional: na VM sem flag (setup já configurou \`.env\`); fora da VM com flag

## Test plan

- [x] Diff limitado às 2 docs (\`DEPLOY_SERVER.md\` + \`siscan-runner-recover.md\`)
- [x] Sintaxe markdown dos callouts \`>\` está consistente com o resto do doc
- [x] Comandos exemplo são copy-pasteáveis (sem aspas tipográficas, sem chars Unicode invisíveis)
- [ ] Validação operacional: próximo operador que rodar \`recover\` standalone (fora de \`\$COMPOSE_DIR\`) consegue se desbloquear sozinho via doc

## Relacionados

- PR #47 (fix doctor stderr) — independente, pode mergear em qualquer ordem
- PR #48 (preflight de utilitários Linux) — independente, pode mergear em qualquer ordem

🤖 Generated with [Claude Code](https://claude.com/claude-code)