### PR TITLE
refactor(runner): extrair _runner.sh + cenário C + flag --token

### DIFF
--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -528,9 +528,11 @@ bash siscan-runner-recover.sh
 O script:
 - Detecta o produto via `.env` (ou aceita `--product` explícito quando `.env` não estiver disponível)
 - Faz pré-flight com o doctor (network + deps + docker + permissions)
-- Diagnostica o cenário (auto-removed ou stale 30d ou OK)
-- **Se for auto-removed**: pede um token novo de registro do runner e refaz o registro
-- **Se for stale 30d**: roda `run.sh --check` (não precisa token)
+- Diagnostica o cenário automaticamente — cobre 8 cenários (N/A, 1, 2, C, A, A2, B, WARN, OK; ver [doc completa](siscan-server-doctor/scripts/siscan-runner-recover.md))
+- **Se for auto-removed (A/A2)**: pede token novo (ou usa `--token <valor>`) e refaz o registro completo
+- **Se for stale 30d (B/WARN)**: roda `run.sh --check` (não precisa token)
+- **Se for serviço systemd ausente (C)**: só `svc.sh install + start` (não precisa token — caminho cirúrgico)
+- **Se for bootstrap (N/A/1/2)**: faz download + register + install + start (pede token)
 - Valida ao fim chamando `check-runner` novamente
 
 > **Token de registro do runner:** quem gera é um administrador do repositório do produto correspondente (`Prisma-Consultoria/siscan-rpa` ou `Prisma-Consultoria/siscan-dashboard`) em `Settings → Actions → Runners → New self-hosted runner`. O token expira em ~1h, então combine com o admin que ele gere **no momento** em que você for executar este passo, e cole o valor quando o script perguntar. O operador da VM não precisa de permissão administrativa no repo.

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -528,7 +528,7 @@ bash siscan-runner-recover.sh
 O script:
 - Detecta o produto via `.env` (ou aceita `--product` explícito quando `.env` não estiver disponível)
 - Faz pré-flight com o doctor (network + deps + docker + permissions)
-- Diagnostica o cenário automaticamente — cobre 8 cenários (N/A, 1, 2, C, A, A2, B, WARN, OK; ver [doc completa](siscan-server-doctor/scripts/siscan-runner-recover.md))
+- Diagnostica o cenário automaticamente — cobre 9 cenários auto-resolvíveis (N/A, 1, 2, C, A, A2, B, WARN, OK) + 1 inconclusivo (UNKNOWN); ver [doc completa](siscan-server-doctor/scripts/siscan-runner-recover.md)
 - **Se for auto-removed (A/A2)**: pede token novo (ou usa `--token <valor>`) e refaz o registro completo
 - **Se for stale 30d (B/WARN)**: roda `run.sh --check` (não precisa token)
 - **Se for serviço systemd ausente (C)**: só `svc.sh install + start` (não precisa token — caminho cirúrgico)

--- a/docs/siscan-server-doctor/scripts/siscan-runner-recover.md
+++ b/docs/siscan-server-doctor/scripts/siscan-runner-recover.md
@@ -1,6 +1,6 @@
 # `siscan-runner-recover.sh` — Recuperação idempotente do runner
 
-Recupera o GitHub Actions self-hosted runner em **8 cenários** — desde "serviço systemd ausente" até "bootstrap do zero". A lógica de download/registro/instalação é compartilhada com `siscan-server-setup.sh` via o módulo `scripts/deploy_server/_runner.sh` (issue #51).
+Recupera o GitHub Actions self-hosted runner em **9 cenários auto-resolvíveis** (OK, N/A, 1, 2, C, A, A2, B, WARN) + 1 estado inconclusivo (UNKNOWN, que orienta passos manuais) — desde "serviço systemd ausente" até "bootstrap do zero". A lógica de download/registro/instalação é compartilhada com `siscan-server-setup.sh` via o módulo `scripts/deploy_server/_runner.sh` (issue #51).
 
 Os 2 cenários originais (A e B) foram descobertos no incidente no servidor parceiro (15/04 → 25/05/2026); o cenário C foi descoberto na VMPRDAPP-RPADASHBOARD em 26/05/2026.
 

--- a/docs/siscan-server-doctor/scripts/siscan-runner-recover.md
+++ b/docs/siscan-server-doctor/scripts/siscan-runner-recover.md
@@ -1,8 +1,25 @@
-# `siscan-runner-recover.sh` — Recuperação cirúrgica do runner
+# `siscan-runner-recover.sh` — Recuperação idempotente do runner
 
-Recupera o GitHub Actions self-hosted runner em **dois cenários** descobertos no incidente no servidor parceiro (15/04 → 25/05/2026):
+Recupera o GitHub Actions self-hosted runner em **8 cenários** — desde "serviço systemd ausente" até "bootstrap do zero". A lógica de download/registro/instalação é compartilhada com `siscan-server-setup.sh` via o módulo `scripts/deploy_server/_runner.sh` (issue #51).
 
-## Cenário A — Auto-removal após 14 dias offline
+Os 2 cenários originais (A e B) foram descobertos no incidente no servidor parceiro (15/04 → 25/05/2026); o cenário C foi descoberto na VMPRDAPP-RPADASHBOARD em 26/05/2026.
+
+## Cenários cobertos (matriz rápida)
+
+| Cenário | Trigger | Token? | Re-registra? | Instala systemd? |
+|---|---|---|---|---|
+| **OK** | tudo online + idade <25d | não | não | não |
+| **N/A** | `~/actions-runner/` não existe | **sim** | sim (bootstrap) | sim |
+| **1** | dir existe mas binários ausentes | **sim** | sim (bootstrap incremental) | sim |
+| **2** | binários OK, `.runner` ausente | **sim** | sim | sim |
+| **C** | `.runner` OK, systemd unit ausente | **não** | não | sim (cirúrgico) |
+| **A** | API `total_count=0` (auto-removed >14d) | **sim** | sim (uninstall + remove + register) | sim |
+| **A2** | API: runner `offline` ou nome mismatch | **sim** | sim (idem A) | sim |
+| **B** | idade ≥30d | não | não | não (só `run.sh --check` + start) |
+| **WARN** | idade 25-29d | não | não | preventivo (idem B) |
+| **UNKNOWN** | sem gh/`GH_TOKEN`/`--token` + estado inconclusivo | — | — | — (orienta) |
+
+### Cenário A — Auto-removal após 14 dias offline
 
 GitHub remove runners offline há > 14 dias. Diagnóstico:
 ```
@@ -10,7 +27,7 @@ gh api repos/<owner>/<repo>/actions/runners → total_count: 0
 ```
 Resolução: re-registrar (precisa token novo).
 
-## Cenário B — Regra dos 30 dias de auto-update
+### Cenário B — Regra dos 30 dias de auto-update
 
 Runner online + serviço ativo, mas GitHub recusa jobs porque o runner ficou > 30 dias sem atualizar sua versão.
 [GitHub docs](https://docs.github.com/en/actions/reference/runners/self-hosted-runners#runner-software-updates-on-self-hosted-runners):
@@ -18,6 +35,21 @@ Runner online + serviço ativo, mas GitHub recusa jobs porque o runner ficou > 3
 > "If you do not perform a software update within 30 days, the GitHub Actions service will not queue jobs to your runner."
 
 Resolução: `sudo -u siscan ./run.sh --check` (**não** precisa token).
+
+### Cenário C — Serviço systemd ausente (novo em #51)
+
+`.runner` continua válido remotamente, mas o systemd unit `actions.runner.*.service` foi desinstalado ou nunca instalado. Detecção é 100% local — não precisa de gh/`GH_TOKEN`. Resolução: `svc.sh install $USER` + `svc.sh start`. **Não pede token** porque o `.runner` ainda é aceito pelo GitHub.
+
+Descoberto na VMPRDAPP-RPADASHBOARD em 26/05/2026: alguém rodou `svc.sh uninstall` (intencional ou não), o `.runner` ficou válido localmente, mas o serviço sumiu do systemd.
+
+### Cenários N/A, 1, 2 — Bootstrap incremental (novos em #51)
+
+Antes de #51, o recover abortava se `~/actions-runner/` não existisse. Após #51, o recover faz o que for necessário pra alcançar estado 4:
+- **N/A**: cria dir + baixa tarball + registra + instala + inicia
+- **1**: baixa + registra + instala + inicia (dir existia mas binários sumiram — limpeza parcial rara)
+- **2**: registra + instala + inicia (binários OK, mas `.runner` foi removido)
+
+Todos os 3 requerem token. Use `--token TOKEN` na CLI ou aguarde o prompt interativo.
 
 ## Sinopse
 
@@ -28,8 +60,17 @@ bash siscan-runner-recover.sh --product dashboard
 bash siscan-runner-recover.sh --product full               # VM que hospeda RPA + Dashboard
 bash siscan-runner-recover.sh --env-file /path/to/.env     # apontar pra um .env em outro caminho
 bash siscan-runner-recover.sh --skip-doctor                # pula pré-flight (debug)
+bash siscan-runner-recover.sh --token ghr_xxx...           # token via CLI (sobrescreve prompt interativo)
 bash siscan-runner-recover.sh --help
 ```
+
+### Flag `--token`
+
+Quando fornecida, sobrescreve o prompt interativo `read -srp "Token: "` dos cenários que precisam de token (N/A, 1, 2, A, A2). Útil para:
+- **Automação** (CI/scripts sem TTY interativo)
+- **UNKNOWN defensivo**: se `gh`/`GH_TOKEN` ausentes e estado local OK + idade <30d, fornecer `--token` força o cenário **A2** (re-registro defensivo, assumindo que o GitHub pode ter auto-removido o runner sem possibilidade de detectar via API)
+
+Sem `--token`, o comportamento histórico do prompt interativo é preservado.
 
 > **Pré-requisito**: o script precisa saber o produto antes de qualquer ação. Resolução em ordem:
 > 1. `--product VALOR` explícito vence sempre.
@@ -85,15 +126,21 @@ Diagnóstico em 4 passos:
 3. **Cruza** os dois pra decidir o cenário
 4. **Executa** a ação correspondente
 
-| Estado da API | Idade local | Cenário | Ação |
-|---|---|---|---|
-| `total_count: 0` | qualquer | **A** Auto-removed | Re-registrar (pede token) |
-| Runner ausente do nome esperado | qualquer | **A'** Nome mismatch | Re-registrar |
-| Runner presente, `offline` | qualquer | **A'** Offline | Re-registrar |
-| Runner presente, `online`, ≥ 30d | ≥ 30d | **B** Regra dos 30d | `run.sh --check` |
-| Runner presente, `online`, 25-29d | 25-29d | **WARN** | `run.sh --check` (preventivo) |
-| Runner presente, `online`, < 25d | < 25d | **OK** | Nada — exit 0 |
-| `~/actions-runner/` ausente | — | **N/A** | Orienta `siscan-server-setup.sh` |
+Detecção é feita por `runner_diagnose` (em `scripts/deploy_server/_runner.sh`), que combina estado local (via `runner_get_state`) e remoto (via `runner_query_api`). Ordem de precedência:
+
+| Estado local | Estado remoto | Idade | Cenário | Ação |
+|---|---|---|---|---|
+| dir ausente | — | — | **N/A** | Bootstrap completo (pede token) |
+| dir OK, binários ausentes | — | — | **1** | Bootstrap incremental (pede token) |
+| binários OK, `.runner` ausente | — | — | **2** | Register + install + start (pede token) |
+| binários + `.runner` OK, systemd unit ausente | — | — | **C** | Install + start (sem token) |
+| tudo local OK | `total_count: 0` | qualquer | **A** | Uninstall + remove + re-register + install + start |
+| tudo local OK | runner offline ou nome mismatch | qualquer | **A2** | Idem A |
+| tudo local OK | runner online | ≥ 30d | **B** | `run.sh --check` + start |
+| tudo local OK | runner online | 25-29d | **WARN** | Idem B (preventivo) |
+| tudo local OK | runner online | < 25d | **OK** | Nada — exit 0 |
+| tudo local OK | API indisponível | < 30d, `--token` setado | **A2** (defensivo) | Idem A |
+| tudo local OK | API indisponível | < 30d, sem `--token` | **UNKNOWN** | Orienta `--token` ou `gh` |
 
 ## Ações por cenário (o que o script faz na VM)
 
@@ -189,9 +236,28 @@ Depois da ação, espera 5s e roda `bash scripts/deploy_server/check-runner.sh -
 ## Comportamento
 
 - **Idempotente**: rodar duas vezes seguidas — a segunda detecta runner OK e sai com exit 0
-- **Não é instalação**: assume `~/actions-runner/` existe. Para VM nova, use `siscan-server-setup.sh`
+- **Cobre instalação do zero** (a partir de #51): cenários N/A, 1 e 2 fazem bootstrap incremental usando as funções do módulo `_runner.sh`. Não é mais necessário chamar `siscan-server-setup.sh` separadamente apenas para o runner.
 - **Reusa identidade**: mantém nome + label do runner conforme manifesto
-- **Cenário B não pede token**: economiza ida ao GitHub UI quando só falta auto-update
+- **Cenário B/WARN/C não pedem token**: economiza ida ao GitHub UI quando só falta auto-update ou só o systemd unit
+- **`--token` sobrescreve prompt**: util para automação e para forçar A2 defensivo quando API não está consultável
+
+## Relação com `siscan-server-setup.sh`
+
+A Fase 7 do setup e o recover compartilham as **mesmas funções** do módulo `scripts/deploy_server/_runner.sh`:
+
+```
+runner_download_binaries  → baixa tarball (estado 1→2)
+runner_register           → config.sh --token (estado 2→3)
+runner_install_service    → svc.sh install (estado 3→4)
+runner_start_service      → svc.sh start
+runner_stop_service       → svc.sh stop (idempotente)
+runner_uninstall_service  → svc.sh uninstall (idempotente)
+runner_remove_registration → config.sh remove (idempotente)
+runner_get_state          → echo N/A|1|2|3|4
+runner_diagnose           → echo OK|N/A|1|2|C|A|A2|B|WARN|UNKNOWN
+```
+
+Por isso, bugs ou melhorias na lógica de runner se propagam automaticamente para ambos os scripts.
 
 ## Exemplo — incidente real no servidor parceiro (25/05/2026)
 
@@ -218,4 +284,5 @@ e valida com `check-runner` no final.
 - [`check-network.md`](check-network.md) — primeiro specialist invocado no pré-flight
 - [`../../TROUBLESHOOTING.md`](../../TROUBLESHOOTING.md) — sintomas e diagnóstico manual
 - [Self-hosted runners reference (GitHub docs)](https://docs.github.com/en/actions/reference/runners/self-hosted-runners)
-- [Task #31](https://github.com/Prisma-Consultoria/assistente-siscan-rpa/issues/31)
+- [Task #31](https://github.com/Prisma-Consultoria/assistente-siscan-rpa/issues/31) — entrega original (cenários A e B)
+- [Task #51](https://github.com/Prisma-Consultoria/assistente-siscan-rpa/issues/51) — refatoração `_runner.sh` + cenários C/N/A/1/2 + flag `--token`

--- a/scripts/deploy_server/_runner.sh
+++ b/scripts/deploy_server/_runner.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# -------------------------------------------
+# _runner.sh — Biblioteca idempotente do GitHub Actions self-hosted runner
+# -------------------------------------------
+# Arquivo: scripts/deploy_server/_runner.sh
+# Propósito: funções de detecção e ação compartilhadas entre
+#            siscan-server-setup.sh (Fase 7) e siscan-runner-recover.sh.
+#            Single-source-of-truth pra manipulação do runner.
+#
+# Sourcing:
+#   source "$(dirname "${BASH_SOURCE[0]}")/_runner.sh"
+#
+# Convenções:
+#   - Detecção (read-only): funções `runner_get_*`, `runner_validate_*`,
+#     `runner_*_present`, `runner_*_active` ecoam valores ou retornam 0/1
+#     sem side-effects.
+#   - Ações (mutadoras): `runner_download_binaries`, `runner_register`,
+#     `runner_*_service`, `runner_remove_registration` retornam 0 em
+#     sucesso e !=0 em falha; logam progresso via ok()/info()/warn() do
+#     caller (não chamam fail/exit — caller decide).
+#
+# Pré-condições do caller:
+#   - ok(), info(), warn() definidos (compatíveis com _common.sh ou com os
+#     helpers locais do siscan-server-setup.sh).
+#   - $RUNNER_DIR é parâmetro explícito (não lido de variável global).
+#
+# Não deve ter side-effects quando sourceado.
+# -------------------------------------------
+
+# Guard contra source duplicado (idempotência)
+[ -n "${_RUNNER_SH_LOADED:-}" ] && return 0
+_RUNNER_SH_LOADED=1
+
+# ════════════════════════════════════════════════════════════════════════════
+# Detecção — read-only (ecoam valores, retornam 0/1)
+# ════════════════════════════════════════════════════════════════════════════
+
+# runner_validate_binaries RUNNER_DIR
+#   Retorna 0 se config.sh e svc.sh presentes e executáveis.
+runner_validate_binaries() {
+    local dir="$1"
+    [ -x "$dir/config.sh" ] && [ -x "$dir/svc.sh" ]
+}
+
+# runner_validate_dot_runner RUNNER_DIR
+#   Retorna 0 se .runner existe (sinal de runner já registrado no GitHub).
+runner_validate_dot_runner() {
+    local dir="$1"
+    [ -f "$dir/.runner" ]
+}
+
+# runner_systemd_present
+#   Retorna 0 se há um systemd unit file 'actions.runner.*.service'
+#   (presença do unit file, não necessariamente serviço ativo).
+runner_systemd_present() {
+    command -v systemctl >/dev/null 2>&1 || return 1
+    systemctl list-unit-files 'actions.runner.*.service' --no-legend 2>/dev/null | grep -q .
+}
+
+# runner_systemd_active
+#   Retorna 0 se há um serviço actions.runner.* com state=active.
+runner_systemd_active() {
+    command -v systemctl >/dev/null 2>&1 || return 1
+    local svc
+    svc=$(systemctl list-units --type=service 'actions.runner.*' --no-legend 2>/dev/null | head -1 | awk '{print $1}')
+    [ -n "$svc" ] || return 1
+    [ "$(systemctl is-active "$svc" 2>/dev/null)" = "active" ]
+}
+
+# runner_get_state RUNNER_DIR
+#   Ecoa o estado da instalação local:
+#     N/A  - diretório RUNNER_DIR não existe
+#     1    - dir existe mas binários (config.sh/svc.sh) ausentes
+#     2    - binários presentes, .runner ausente (registro não feito)
+#     3    - binários + .runner presentes, systemd unit ausente
+#     4    - tudo presente (caller pode usar runner_systemd_active pra
+#            distinguir 4-ativo de 4-inativo)
+runner_get_state() {
+    local dir="$1"
+    if [ ! -d "$dir" ]; then
+        echo "N/A"; return 0
+    fi
+    if ! runner_validate_binaries "$dir"; then
+        echo "1"; return 0
+    fi
+    if ! runner_validate_dot_runner "$dir"; then
+        echo "2"; return 0
+    fi
+    if ! runner_systemd_present; then
+        echo "3"; return 0
+    fi
+    echo "4"
+}
+
+# runner_local_age_days RUNNER_DIR
+#   Ecoa idade em dias da última auto-atualização do runner.
+#   Prioridade: .runner_migrated > _diag/Runner_*.log > .runner.
+#   Ecoa 999 se não conseguiu determinar.
+runner_local_age_days() {
+    local dir="$1"
+    local age_file=""
+    if [ -f "$dir/.runner_migrated" ]; then
+        age_file="$dir/.runner_migrated"
+    elif [ -d "$dir/_diag" ]; then
+        age_file=$(ls -t "$dir/_diag"/Runner_*.log 2>/dev/null | head -1)
+    elif [ -f "$dir/.runner" ]; then
+        age_file="$dir/.runner"
+    fi
+    if [ -z "$age_file" ] || [ ! -e "$age_file" ]; then
+        echo 999; return 0
+    fi
+    local age_epoch now_epoch
+    age_epoch=$(stat -c '%Y' "$age_file" 2>/dev/null || echo 0)
+    now_epoch=$(date +%s)
+    echo $(( (now_epoch - age_epoch) / 86400 ))
+}
+
+# runner_query_api OWNER REPO
+#   Ecoa o JSON de repos/OWNER/REPO/actions/runners (resposta da API).
+#   Usa gh CLI se autenticado; senão curl com GH_TOKEN; senão ecoa vazio.
+runner_query_api() {
+    local owner="$1" repo="$2"
+    if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+        gh api "repos/$owner/$repo/actions/runners" 2>/dev/null || echo ""
+    elif [ -n "${GH_TOKEN:-}" ]; then
+        curl -s -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/$owner/$repo/actions/runners" 2>/dev/null || echo ""
+    else
+        echo ""
+    fi
+}
+
+# runner_diagnose RUNNER_DIR EXPECTED_NAME OWNER REPO [HAS_TOKEN_ARG]
+#   Detecta o cenário cruzando estado local + remoto.
+#   HAS_TOKEN_ARG (opcional, "true"|"false"): se "true", força UNKNOWN→A2
+#   quando a API não está disponível mas a operadora forneceu --token
+#   (re-registro defensivo).
+#   Ecoa: N/A|1|2|C|A|A2|B|WARN|OK|UNKNOWN
+runner_diagnose() {
+    local dir="$1" expected_name="$2" owner="$3" repo="$4"
+    local has_token="${5:-false}"
+    local state age_days runners_json total remote_status
+
+    state=$(runner_get_state "$dir")
+    case "$state" in
+        N/A|1|2|3)
+            # Estados locais antecedem qualquer consulta remota.
+            # N/A, 1, 2 → caller decide (bootstrap incremental).
+            # 3        → cenário C (serviço ausente; .runner válido).
+            case "$state" in
+                3) echo "C" ;;
+                *) echo "$state" ;;
+            esac
+            return 0
+            ;;
+    esac
+
+    # state=4: tudo local presente, decidir entre A/A2/B/WARN/OK via API + idade
+    age_days=$(runner_local_age_days "$dir")
+    runners_json=$(runner_query_api "$owner" "$repo")
+
+    if [ -z "$runners_json" ]; then
+        if [ "$age_days" -ge 30 ]; then
+            echo "B"; return 0
+        elif [ "$age_days" -ge 25 ]; then
+            echo "WARN"; return 0
+        elif [ "$has_token" = "true" ]; then
+            # Operadora forneceu token defensivamente → assume A2
+            echo "A2"; return 0
+        else
+            echo "UNKNOWN"; return 0
+        fi
+    fi
+
+    total=$(echo "$runners_json" | jq -r '.total_count // 0')
+    if [ "$total" -eq 0 ]; then
+        echo "A"; return 0
+    fi
+
+    remote_status=$(echo "$runners_json" | jq -r ".runners[] | select(.name == \"$expected_name\") | .status" | head -1)
+    if [ -z "$remote_status" ] || [ "$remote_status" = "offline" ]; then
+        echo "A2"; return 0
+    fi
+
+    # Runner online na API — só pode ser B/WARN/OK pela idade
+    if [ "$age_days" -ge 30 ]; then
+        echo "B"
+    elif [ "$age_days" -ge 25 ]; then
+        echo "WARN"
+    else
+        echo "OK"
+    fi
+}
+
+# ════════════════════════════════════════════════════════════════════════════
+# Ações — mutadoras (retornam 0 em sucesso, !=0 em falha)
+# ════════════════════════════════════════════════════════════════════════════
+
+# runner_download_binaries RUNNER_DIR
+#   Detecta arquitetura, consulta versão mais recente, baixa e extrai.
+#   Retorna 1 em erro de arch/rede/extração.
+runner_download_binaries() {
+    local dir="$1"
+    local arch runner_arch version url tarball
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64)  runner_arch="x64" ;;
+        aarch64) runner_arch="arm64" ;;
+        *) printf "Arquitetura não suportada pelo runner: %s\n" "$arch" >&2; return 1 ;;
+    esac
+    info "Arquitetura: $arch → linux-$runner_arch"
+    info "Consultando versão mais recente do runner..."
+    version=$(curl -fsSL \
+        "https://api.github.com/repos/actions/runner/releases/latest" 2>/dev/null \
+        | grep '"tag_name"' \
+        | sed 's/.*"v\([^"]*\)".*/\1/' \
+        | head -1)
+    if [ -z "$version" ]; then
+        printf "Não foi possível obter a versão do runner. Verifique conectividade com github.com.\n" >&2
+        return 1
+    fi
+    info "Versão: $version"
+    mkdir -p "$dir"
+    tarball="$dir/actions-runner-linux-${runner_arch}-${version}.tar.gz"
+    url="https://github.com/actions/runner/releases/download/v${version}/actions-runner-linux-${runner_arch}-${version}.tar.gz"
+    info "Baixando runner em $tarball..."
+    if ! curl -fsSL --progress-bar -o "$tarball" "$url"; then
+        rm -f "$tarball"
+        printf "Falha ao baixar o runner. Verifique a conectividade.\n" >&2
+        return 1
+    fi
+    info "Extraindo em $dir..."
+    if ! tar xzf "$tarball" -C "$dir"; then
+        rm -f "$tarball"
+        printf "Falha ao extrair tarball do runner.\n" >&2
+        return 1
+    fi
+    rm -f "$tarball"
+    ok "Runner extraído (versão $version)"
+}
+
+# runner_register RUNNER_DIR URL TOKEN NAME LABEL
+#   Registra o runner via config.sh --token. Usa --unattended --replace
+#   (idempotente quanto a nome+label).
+runner_register() {
+    local dir="$1" url="$2" token="$3" name="$4" label="$5"
+    [ -n "$token" ] || { printf "Token vazio — abortando registro.\n" >&2; return 1; }
+    info "Registrando runner (name=$name, label=$label)..."
+    if ! (cd "$dir" && ./config.sh \
+            --url "$url" \
+            --token "$token" \
+            --labels "$label" \
+            --name "$name" \
+            --unattended \
+            --replace); then
+        printf "Falha ao registrar o runner. Verifique URL e token (tokens expiram em ~5min).\n" >&2
+        return 1
+    fi
+    ok "Runner registrado: $name [$label]"
+}
+
+# runner_install_service RUNNER_DIR USER
+#   Instala o systemd unit do runner como serviço para USER.
+runner_install_service() {
+    local dir="$1" user="$2"
+    info "Instalando runner como serviço systemd (usuário: $user)..."
+    if ! sudo bash -c "cd '$dir' && ./svc.sh install '$user'"; then
+        printf "Falha ao instalar serviço systemd.\n" >&2
+        return 1
+    fi
+    ok "svc.sh install"
+}
+
+# runner_start_service RUNNER_DIR
+runner_start_service() {
+    local dir="$1"
+    info "Iniciando serviço do runner..."
+    if ! sudo bash -c "cd '$dir' && ./svc.sh start"; then
+        printf "Falha ao iniciar serviço do runner.\n" >&2
+        return 1
+    fi
+    ok "svc.sh start"
+}
+
+# runner_stop_service RUNNER_DIR
+#   Idempotente — warn (não fail) se já estava parado/ausente.
+runner_stop_service() {
+    local dir="$1"
+    info "Parando serviço do runner..."
+    if sudo bash -c "cd '$dir' && ./svc.sh stop" 2>/dev/null; then
+        ok "svc.sh stop"
+    else
+        warn "svc.sh stop (já parado ou serviço ausente?)"
+    fi
+}
+
+# runner_uninstall_service RUNNER_DIR
+#   Idempotente — warn se já estava desinstalado.
+runner_uninstall_service() {
+    local dir="$1"
+    info "Desinstalando serviço systemd..."
+    if sudo bash -c "cd '$dir' && ./svc.sh uninstall" 2>/dev/null; then
+        ok "svc.sh uninstall"
+    else
+        warn "svc.sh uninstall (já desinstalado?)"
+    fi
+}
+
+# runner_remove_registration RUNNER_DIR TOKEN
+#   Remove o registro local via config.sh remove. Idempotente quanto a
+#   404 (runner já foi auto-removido pelo GitHub).
+runner_remove_registration() {
+    local dir="$1" token="$2"
+    info "Removendo registro local (config.sh remove)..."
+    if (cd "$dir" && ./config.sh remove --token "$token") 2>/dev/null; then
+        ok "config remove"
+    else
+        warn "config remove (404 esperado se runner já foi auto-removido)"
+    fi
+}
+
+# runner_service_status_active RUNNER_DIR
+#   Retorna 0 se 'svc.sh status' reporta active/running.
+#   Usado por callers que querem checar antes de tentar install+start.
+runner_service_status_active() {
+    local dir="$1"
+    local status_output
+    status_output=$(sudo "$dir/svc.sh" status 2>/dev/null || true)
+    echo "$status_output" | grep -qi "active\|running"
+}

--- a/scripts/deploy_server/_runner.sh
+++ b/scripts/deploy_server/_runner.sh
@@ -49,22 +49,42 @@ runner_validate_dot_runner() {
     [ -f "$dir/.runner" ]
 }
 
-# runner_systemd_present
-#   Retorna 0 se há um systemd unit file 'actions.runner.*.service'
-#   (presença do unit file, não necessariamente serviço ativo).
-runner_systemd_present() {
-    command -v systemctl >/dev/null 2>&1 || return 1
-    systemctl list-unit-files 'actions.runner.*.service' --no-legend 2>/dev/null | grep -q .
+# runner_unit_name RUNNER_DIR
+#   Ecoa o nome da systemd unit associada a este RUNNER_DIR, ou vazio se
+#   não houver. O svc.sh do GitHub grava o nome da unit (ex.:
+#   'actions.runner.OWNER-REPO.NAME.service') no marker `$dir/.service`
+#   durante `svc.sh install`. Esse marker é o único vínculo confiável
+#   entre um diretório de runner e sua unit específica em hosts com
+#   múltiplos runners.
+runner_unit_name() {
+    local dir="$1"
+    [ -f "$dir/.service" ] || { echo ""; return 0; }
+    tr -d '[:space:]' < "$dir/.service" 2>/dev/null
 }
 
-# runner_systemd_active
-#   Retorna 0 se há um serviço actions.runner.* com state=active.
-runner_systemd_active() {
+# runner_systemd_present RUNNER_DIR
+#   Retorna 0 se a systemd unit *deste* RUNNER_DIR está instalada.
+#   Usa o marker `$dir/.service` (escrito por `svc.sh install`) — em VMs
+#   com múltiplos runners, isso garante que detectemos só a unit do dir
+#   passado, não qualquer `actions.runner.*.service` do host.
+runner_systemd_present() {
+    local dir="$1"
     command -v systemctl >/dev/null 2>&1 || return 1
-    local svc
-    svc=$(systemctl list-units --type=service 'actions.runner.*' --no-legend 2>/dev/null | head -1 | awk '{print $1}')
-    [ -n "$svc" ] || return 1
-    [ "$(systemctl is-active "$svc" 2>/dev/null)" = "active" ]
+    local unit
+    unit=$(runner_unit_name "$dir")
+    [ -n "$unit" ] || return 1
+    systemctl list-unit-files "$unit" --no-legend 2>/dev/null | grep -q .
+}
+
+# runner_systemd_active RUNNER_DIR
+#   Retorna 0 se a unit *deste* RUNNER_DIR está com state=active.
+runner_systemd_active() {
+    local dir="$1"
+    command -v systemctl >/dev/null 2>&1 || return 1
+    local unit
+    unit=$(runner_unit_name "$dir")
+    [ -n "$unit" ] || return 1
+    [ "$(systemctl is-active "$unit" 2>/dev/null)" = "active" ]
 }
 
 # runner_get_state RUNNER_DIR
@@ -86,7 +106,7 @@ runner_get_state() {
     if ! runner_validate_dot_runner "$dir"; then
         echo "2"; return 0
     fi
-    if ! runner_systemd_present; then
+    if ! runner_systemd_present "$dir"; then
         echo "3"; return 0
     fi
     echo "4"
@@ -253,7 +273,7 @@ runner_register() {
             --name "$name" \
             --unattended \
             --replace); then
-        printf "Falha ao registrar o runner. Verifique URL e token (tokens expiram em ~5min).\n" >&2
+        printf "Falha ao registrar o runner. Verifique URL e token (tokens expiram em poucos minutos).\n" >&2
         return 1
     fi
     ok "Runner registrado: $name [$label]"

--- a/siscan-runner-recover.sh
+++ b/siscan-runner-recover.sh
@@ -48,6 +48,8 @@ DOCTOR_SCRIPT="$SCRIPT_DIR/siscan-server-doctor.sh"
 SPECIALIST_NAME="recover"
 # shellcheck source=scripts/deploy_server/_common.sh
 source "$SPECIALISTS_DIR/_common.sh"
+# shellcheck source=scripts/deploy_server/_runner.sh
+source "$SPECIALISTS_DIR/_runner.sh"
 
 # Force human mode — script interativo, não json/quiet
 OUTPUT_MODE="human"
@@ -61,6 +63,7 @@ COMPOSE_DIR="${COMPOSE_DIR:-$(pwd)}"
 ENV_FILE="${COMPOSE_DIR}/.env"
 SISCAN_PRODUCT=""
 SKIP_DOCTOR=false
+TOKEN_ARG=""
 CURRENT_USER="$(whoami)"
 
 usage() {
@@ -72,13 +75,19 @@ Opções:
   --env-file FILE                Override do .env (default: \$COMPOSE_DIR/.env ou \$CWD/.env)
   --runner-dir DIR               Override do diretório do runner (default: ~/actions-runner)
   --skip-doctor                  Pula pré-flight via doctor (debugging)
+  --token TOKEN                  Token de registro do runner (alternativa a gh/GH_TOKEN);
+                                 quando fornecido, sobrescreve o prompt interativo
   -h, --help                     Esta ajuda
 
-Cenários detectados automaticamente via GitHub API:
-  A) Auto-removal (>14d offline)  → re-registro (pede token novo)
-  B) Regra dos 30 dias            → run.sh --check (sem token)
-  OK) Runner saudável             → exit 0, nada a fazer
-  N/A) Runner nunca instalado     → orienta siscan-server-setup.sh
+Cenários detectados automaticamente:
+  OK   ) Runner saudável                                   → exit 0, nada a fazer
+  N/A  ) ~/actions-runner não existe                       → bootstrap completo (pede token)
+  C    ) .runner OK + systemd unit ausente                 → svc.sh install + start (sem token)
+  A    ) total_count=0 na API (auto-removal >14d)          → uninstall + register + install (pede token)
+  A2   ) runner offline ou nome mismatch na API            → uninstall + register + install (pede token)
+  B    ) idade >=30d                                       → run.sh --check (sem token)
+  WARN ) idade 25-29d                                      → run.sh --check preventivo (sem token)
+  UNKNOWN) sem gh/GH_TOKEN/--token + estado inconclusivo   → orienta passos manuais
 
 Exit code: 0 = OK · 1 = falha no recovery · 2 = pré-condição/uso
 EOF
@@ -93,6 +102,8 @@ while [ $# -gt 0 ]; do
         --runner-dir)   RUNNER_DIR="${2:-}"; shift 2 ;;
         --runner-dir=*) RUNNER_DIR="${1#*=}"; shift ;;
         --skip-doctor)  SKIP_DOCTOR=true; shift ;;
+        --token)        TOKEN_ARG="${2:-}"; shift 2 ;;
+        --token=*)      TOKEN_ARG="${1#*=}"; shift ;;
         -h|--help)      usage; exit 0 ;;
         *) echo "argumento desconhecido: $1" >&2; usage >&2; exit 2 ;;
     esac
@@ -133,20 +144,18 @@ info "Nome do runner esperado: $EXPECTED_NAME"
 info "Label: $RUNNER_LABEL"
 
 # ────────────────────────────────────────────────────────────────────────────
-# 2. Pré-condição: ~/actions-runner/ deve existir
+# 2. Inspeção do estado local — sem abortar; o cenário decide
 # ────────────────────────────────────────────────────────────────────────────
-step_print "2/6 — Validação da instalação local"
+step_print "2/6 — Inspeção da instalação local"
 
-if [ ! -d "$RUNNER_DIR" ]; then
-    fail "Diretório do runner não existe: $RUNNER_DIR
-       Esse script é pra recuperar runner JÁ INSTALADO. Para nova instalação:
-       bash siscan-server-setup.sh --product $SISCAN_PRODUCT"
-fi
-if [ ! -x "$RUNNER_DIR/config.sh" ] || [ ! -x "$RUNNER_DIR/svc.sh" ]; then
-    fail "Binários do runner ausentes em $RUNNER_DIR (config.sh ou svc.sh).
-       Reinstale via: bash siscan-server-setup.sh --product $SISCAN_PRODUCT"
-fi
-ok "Binários do runner presentes em $RUNNER_DIR"
+LOCAL_STATE=$(runner_get_state "$RUNNER_DIR")
+case "$LOCAL_STATE" in
+    N/A) info "Diretório do runner ausente — será criado pelo bootstrap (cenário N/A)" ;;
+    1)   info "Diretório existe mas binários ausentes — bootstrap incremental" ;;
+    2)   info ".runner ausente — registro necessário" ;;
+    3)   ok "Binários + .runner OK; systemd unit ausente (cenário C provável)" ;;
+    4)   ok "Instalação local completa em $RUNNER_DIR" ;;
+esac
 
 # ────────────────────────────────────────────────────────────────────────────
 # 3. Pré-flight via doctor (não inclui check-runner — é o que vamos consertar)
@@ -171,141 +180,143 @@ else
 fi
 
 # ────────────────────────────────────────────────────────────────────────────
-# 4. Diagnóstico do cenário
+# 4. Diagnóstico do cenário (delegado para _runner.sh)
 # ────────────────────────────────────────────────────────────────────────────
 step_print "4/6 — Diagnóstico do estado do runner"
 
-# 4a — Idade local
-age_days=999
-age_source=""
-age_file=""
-if [ -f "$RUNNER_DIR/.runner_migrated" ]; then
-    age_file="$RUNNER_DIR/.runner_migrated"
-    age_source="último upgrade (.runner_migrated)"
-elif [ -d "$RUNNER_DIR/_diag" ]; then
-    age_file=$(ls -t "$RUNNER_DIR/_diag"/Runner_*.log 2>/dev/null | head -1)
-    [ -n "$age_file" ] && age_source="último log em _diag/"
-elif [ -f "$RUNNER_DIR/.runner" ]; then
-    age_file="$RUNNER_DIR/.runner"
-    age_source="data de registro (.runner)"
+age_days=$(runner_local_age_days "$RUNNER_DIR")
+if [ "$age_days" -ne 999 ]; then
+    info "Idade do runner: $age_days dia(s)"
 fi
 
-if [ -n "$age_source" ] && [ -e "$age_file" ]; then
-    age_epoch=$(stat -c '%Y' "$age_file" 2>/dev/null || echo 0)
-    now_epoch=$(date +%s)
-    age_days=$(( (now_epoch - age_epoch) / 86400 ))
-    info "Idade do runner: $age_days dia(s) ($age_source)"
-else
-    warn "Não foi possível determinar idade do runner — assumindo velho"
-fi
+HAS_TOKEN_ARG="false"
+[ -n "$TOKEN_ARG" ] && HAS_TOKEN_ARG="true"
 
-# 4b — Estado remoto via GitHub API
-runners_json=""
-if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-    runners_json=$(gh api "repos/$REPO_OWNER/$REPO_NAME/actions/runners" 2>/dev/null || echo "")
-elif [ -n "${GH_TOKEN:-}" ]; then
-    runners_json=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
-        "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/actions/runners" 2>/dev/null || echo "")
-fi
+scenario=$(runner_diagnose "$RUNNER_DIR" "$EXPECTED_NAME" "$REPO_OWNER" "$REPO_NAME" "$HAS_TOKEN_ARG")
 
-scenario="UNKNOWN"
-if [ -z "$runners_json" ]; then
-    warn "API GitHub indisponível (sem gh ou GH_TOKEN). Cenário A vs B detectável só via idade."
-    if [ "$age_days" -ge 30 ]; then
-        scenario="B"
-        info "→ Cenário B (regra dos 30 dias) — runner com $age_days d"
-    fi
-else
-    total=$(echo "$runners_json" | jq -r '.total_count // 0')
-    if [ "$total" -eq 0 ]; then
-        scenario="A"
-        info "→ Cenário A (auto-removal): total_count=0 — runner removido pelo GitHub"
-    else
-        remote_status=$(echo "$runners_json" | jq -r ".runners[] | select(.name == \"$EXPECTED_NAME\") | .status" | head -1)
-        if [ -z "$remote_status" ]; then
-            scenario="A2"
-            names=$(echo "$runners_json" | jq -r '.runners[].name' | paste -sd, -)
-            info "→ Cenário A' (nome mismatch): esperado '$EXPECTED_NAME' não está na API"
-            info "   Registrados: $names"
-        elif [ "$remote_status" = "offline" ]; then
-            scenario="A2"
-            info "→ Cenário A' (offline na API): runner registrado mas reportando offline"
-        elif [ "$age_days" -ge 30 ]; then
-            scenario="B"
-            info "→ Cenário B (regra dos 30 dias): runner online mas $age_days d sem update"
-        elif [ "$age_days" -ge 25 ]; then
-            scenario="WARN"
-            info "→ AVISO: runner $age_days d sem update (regra dos 30d em $((30 - age_days))d)"
+case "$scenario" in
+    OK)
+        ok "Runner saudável (online, $age_days d desde último update) — nada a fazer."
+        exit 0
+        ;;
+    N/A) info "→ Cenário N/A: $RUNNER_DIR não existe — bootstrap completo" ;;
+    1)   info "→ Cenário 1: binários ausentes — bootstrap incremental (download + register + install + start)" ;;
+    2)   info "→ Cenário 2: .runner ausente — register + install + start" ;;
+    C)   info "→ Cenário C: systemd unit ausente, .runner válido — install + start (sem token)" ;;
+    A)   info "→ Cenário A (auto-removal): total_count=0 na API — re-registro completo" ;;
+    A2)
+        if [ "$HAS_TOKEN_ARG" = "true" ] && ! command -v gh >/dev/null 2>&1 && [ -z "${GH_TOKEN:-}" ]; then
+            info "→ Cenário A' (defensivo): --token fornecido sem API consultável — assume runner removido"
         else
-            ok "Runner saudável (online, $age_days d desde último update) — nada a fazer."
-            exit 0
+            info "→ Cenário A' (offline/nome mismatch na API) — re-registro completo"
         fi
-    fi
-fi
+        ;;
+    B)   info "→ Cenário B (regra dos 30 dias): $age_days d — run.sh --check" ;;
+    WARN) info "→ AVISO ($age_days d): regra dos 30d em $((30 - age_days)) d — run.sh --check preventivo" ;;
+    UNKNOWN)
+        warn "API GitHub indisponível (sem gh/GH_TOKEN/--token) e idade local insuficiente pra disparar B/WARN."
+        ;;
+esac
 
 # ────────────────────────────────────────────────────────────────────────────
-# 5. Execução do recovery
+# 5. Execução do recovery (delegada para _runner.sh)
 # ────────────────────────────────────────────────────────────────────────────
 step_print "5/6 — Execução do recovery"
 
-cd "$RUNNER_DIR" || fail "Não foi possível entrar em $RUNNER_DIR"
+REPO_URL="https://github.com/$REPO_OWNER/$REPO_NAME"
 
-case "$scenario" in
-    A|A2)
-        printf "${YELLOW}Re-registro requer token novo (expira em ~5 min).${NC}\n"
-        printf "${WHITE}Gere agora em:${NC} ${CYAN}https://github.com/$REPO_OWNER/$REPO_NAME/settings/actions/runners/new${NC}\n\n"
+# prompt_token_if_needed — usa --token se fornecido; senão pergunta interativo.
+# Mensagem de origem do token vira "args.fornecido" ou "prompt.interativo".
+prompt_token_if_needed() {
+    if [ -n "$TOKEN_ARG" ]; then
+        TOKEN="$TOKEN_ARG"
+        info "Token fornecido via --token"
+    else
+        printf "${YELLOW}Token de registro requerido (expira em ~5 min).${NC}\n"
+        printf "${WHITE}Gere agora em:${NC} ${CYAN}%s/settings/actions/runners/new${NC}\n\n" "$REPO_URL"
         # shellcheck disable=SC2162
         read -srp "Token: " TOKEN
         echo ""
-        [ -n "$TOKEN" ] || fail "Token vazio. Abortando."
+    fi
+    [ -n "$TOKEN" ] || fail "Token vazio. Abortando."
+}
 
-        info "Parando serviço..."
-        sudo ./svc.sh stop 2>/dev/null && ok "svc.sh stop" || warn "svc.sh stop (já parado?)"
+case "$scenario" in
+    N/A)
+        # Bootstrap completo — recover instalando do zero
+        runner_download_binaries "$RUNNER_DIR" \
+            || fail "Falha no download do runner. Verifique conectividade com github.com."
+        prompt_token_if_needed
+        runner_register "$RUNNER_DIR" "$REPO_URL" "$TOKEN" "$EXPECTED_NAME" "$RUNNER_LABEL" \
+            || fail "Falha ao registrar o runner."
+        runner_install_service "$RUNNER_DIR" "$CURRENT_USER" \
+            || fail "Falha ao instalar systemd unit."
+        runner_start_service "$RUNNER_DIR" \
+            || fail "Falha ao iniciar serviço do runner."
+        ;;
 
-        info "Desinstalando serviço..."
-        sudo ./svc.sh uninstall 2>/dev/null && ok "svc.sh uninstall" || warn "svc.sh uninstall (já desinstalado?)"
+    1)
+        # Diretório existe mas binários ausentes (estado raro — limpeza parcial)
+        runner_download_binaries "$RUNNER_DIR" \
+            || fail "Falha no download do runner."
+        prompt_token_if_needed
+        runner_register "$RUNNER_DIR" "$REPO_URL" "$TOKEN" "$EXPECTED_NAME" "$RUNNER_LABEL" \
+            || fail "Falha ao registrar o runner."
+        runner_install_service "$RUNNER_DIR" "$CURRENT_USER" \
+            || fail "Falha ao instalar systemd unit."
+        runner_start_service "$RUNNER_DIR" \
+            || fail "Falha ao iniciar serviço do runner."
+        ;;
 
-        info "Removendo registro local (config.sh remove)..."
-        ./config.sh remove --token "$TOKEN" 2>/dev/null && ok "config remove" || warn "config remove (404 esperado se runner já foi auto-removido)"
+    2)
+        # Binários presentes, .runner ausente
+        prompt_token_if_needed
+        runner_register "$RUNNER_DIR" "$REPO_URL" "$TOKEN" "$EXPECTED_NAME" "$RUNNER_LABEL" \
+            || fail "Falha ao registrar o runner."
+        runner_install_service "$RUNNER_DIR" "$CURRENT_USER" \
+            || fail "Falha ao instalar systemd unit."
+        runner_start_service "$RUNNER_DIR" \
+            || fail "Falha ao iniciar serviço do runner."
+        ;;
 
-        info "Re-registrando com novo token..."
-        if ./config.sh \
-            --url "https://github.com/$REPO_OWNER/$REPO_NAME" \
-            --token "$TOKEN" \
-            --name "$EXPECTED_NAME" \
-            --labels "$RUNNER_LABEL" \
-            --unattended --replace; then
-            ok "config register OK (name=$EXPECTED_NAME, label=$RUNNER_LABEL)"
-        else
-            fail "Falha no config.sh — verifique o token (expira em ~5min) e a URL do repo"
-        fi
+    C)
+        # .runner válido, systemd unit ausente — caminho cirúrgico, sem token
+        runner_install_service "$RUNNER_DIR" "$CURRENT_USER" \
+            || fail "Falha ao instalar systemd unit."
+        runner_start_service "$RUNNER_DIR" \
+            || fail "Falha ao iniciar serviço do runner."
+        ;;
 
-        info "Instalando serviço systemd..."
-        sudo ./svc.sh install "$CURRENT_USER" && ok "svc.sh install" || fail "svc.sh install falhou"
-
-        info "Iniciando serviço..."
-        sudo ./svc.sh start && ok "svc.sh start" || fail "svc.sh start falhou"
+    A|A2)
+        prompt_token_if_needed
+        runner_stop_service "$RUNNER_DIR"
+        runner_uninstall_service "$RUNNER_DIR"
+        runner_remove_registration "$RUNNER_DIR" "$TOKEN"
+        runner_register "$RUNNER_DIR" "$REPO_URL" "$TOKEN" "$EXPECTED_NAME" "$RUNNER_LABEL" \
+            || fail "Falha no config.sh — verifique o token (expira em ~5min) e a URL do repo."
+        runner_install_service "$RUNNER_DIR" "$CURRENT_USER" \
+            || fail "svc.sh install falhou."
+        runner_start_service "$RUNNER_DIR" \
+            || fail "svc.sh start falhou."
         ;;
 
     B|WARN)
-        info "Parando serviço (sem desinstalar)..."
-        sudo ./svc.sh stop && ok "svc.sh stop" || warn "svc.sh stop (já parado?)"
-
+        runner_stop_service "$RUNNER_DIR"
         info "Forçando auto-update via 'run.sh --check' (pode demorar ~30s)..."
-        if sudo -u "$CURRENT_USER" ./run.sh --check; then
+        if sudo -u "$CURRENT_USER" "$RUNNER_DIR/run.sh" --check; then
             ok "run.sh --check OK (runner atualizado)"
         else
-            fail "run.sh --check retornou erro — runner pode estar com problema mais sério"
+            fail "run.sh --check retornou erro — runner pode estar com problema mais sério."
         fi
-
-        info "Reiniciando serviço..."
-        sudo ./svc.sh start && ok "svc.sh start" || fail "svc.sh start falhou"
+        runner_start_service "$RUNNER_DIR" \
+            || fail "svc.sh start falhou."
         ;;
 
     *)
         fail "Cenário desconhecido — nada a fazer automaticamente.
        Rode 'bash $DOCTOR_SCRIPT --only check-runner' para diagnóstico detalhado,
-       ou 'bash siscan-server-setup.sh --product $SISCAN_PRODUCT' para re-instalação completa."
+       ou 'bash siscan-server-setup.sh --product $SISCAN_PRODUCT' para re-instalação completa.
+       Alternativa: forneça --token <novo> para forçar fluxo A2 defensivo."
         ;;
 esac
 

--- a/siscan-runner-recover.sh
+++ b/siscan-runner-recover.sh
@@ -82,6 +82,8 @@ Opções:
 Cenários detectados automaticamente:
   OK   ) Runner saudável                                   → exit 0, nada a fazer
   N/A  ) ~/actions-runner não existe                       → bootstrap completo (pede token)
+  1    ) dir existe mas binários ausentes                  → bootstrap incremental (pede token)
+  2    ) binários OK, .runner ausente                      → register + install + start (pede token)
   C    ) .runner OK + systemd unit ausente                 → svc.sh install + start (sem token)
   A    ) total_count=0 na API (auto-removal >14d)          → uninstall + register + install (pede token)
   A2   ) runner offline ou nome mismatch na API            → uninstall + register + install (pede token)
@@ -93,16 +95,28 @@ Exit code: 0 = OK · 1 = falha no recovery · 2 = pré-condição/uso
 EOF
 }
 
+# _require_value FLAG VALUE — valida que flag --foo tem argumento de valor.
+# Usado pelos flags que esperam VALUE (--product, --env-file, --runner-dir, --token).
+# Sem essa validação, "--flag" no fim da linha (sem valor) causaria loop infinito
+# no while, pois `shift 2` falha silenciosamente quando só resta 1 argumento.
+_require_value() {
+    if [ $# -lt 2 ] || [ -z "${2:-}" ]; then
+        printf "erro: %s requer um valor\n" "$1" >&2
+        usage >&2
+        exit 2
+    fi
+}
+
 while [ $# -gt 0 ]; do
     case "$1" in
-        --product)      SISCAN_PRODUCT="${2:-}"; shift 2 ;;
+        --product)      _require_value "$@"; SISCAN_PRODUCT="$2"; shift 2 ;;
         --product=*)    SISCAN_PRODUCT="${1#*=}"; shift ;;
-        --env-file)     ENV_FILE="${2:-}"; shift 2 ;;
+        --env-file)     _require_value "$@"; ENV_FILE="$2"; shift 2 ;;
         --env-file=*)   ENV_FILE="${1#*=}"; shift ;;
-        --runner-dir)   RUNNER_DIR="${2:-}"; shift 2 ;;
+        --runner-dir)   _require_value "$@"; RUNNER_DIR="$2"; shift 2 ;;
         --runner-dir=*) RUNNER_DIR="${1#*=}"; shift ;;
         --skip-doctor)  SKIP_DOCTOR=true; shift ;;
-        --token)        TOKEN_ARG="${2:-}"; shift 2 ;;
+        --token)        _require_value "$@"; TOKEN_ARG="$2"; shift 2 ;;
         --token=*)      TOKEN_ARG="${1#*=}"; shift ;;
         -h|--help)      usage; exit 0 ;;
         *) echo "argumento desconhecido: $1" >&2; usage >&2; exit 2 ;;
@@ -232,8 +246,8 @@ prompt_token_if_needed() {
         TOKEN="$TOKEN_ARG"
         info "Token fornecido via --token"
     else
-        printf "${YELLOW}Token de registro requerido (expira em ~5 min).${NC}\n"
-        printf "${WHITE}Gere agora em:${NC} ${CYAN}%s/settings/actions/runners/new${NC}\n\n" "$REPO_URL"
+        printf "${YELLOW}Token de registro requerido — expira em poucos minutos; gere agora.${NC}\n"
+        printf "${WHITE}URL:${NC} ${CYAN}%s/settings/actions/runners/new${NC}\n\n" "$REPO_URL"
         # shellcheck disable=SC2162
         read -srp "Token: " TOKEN
         echo ""
@@ -293,7 +307,7 @@ case "$scenario" in
         runner_uninstall_service "$RUNNER_DIR"
         runner_remove_registration "$RUNNER_DIR" "$TOKEN"
         runner_register "$RUNNER_DIR" "$REPO_URL" "$TOKEN" "$EXPECTED_NAME" "$RUNNER_LABEL" \
-            || fail "Falha no config.sh — verifique o token (expira em ~5min) e a URL do repo."
+            || fail "Falha no config.sh — verifique o token (expira em poucos minutos) e a URL do repo."
         runner_install_service "$RUNNER_DIR" "$CURRENT_USER" \
             || fail "svc.sh install falhou."
         runner_start_service "$RUNNER_DIR" \

--- a/siscan-server-setup.sh
+++ b/siscan-server-setup.sh
@@ -65,6 +65,7 @@ done
 RUNNER_DIR="${RUNNER_DIR:-${HOME}/actions-runner}"
 CURRENT_USER="$(whoami)"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPECIALISTS_DIR="${SCRIPT_DIR}/scripts/deploy_server"
 
 # ────────────────────────────────────────────────────────────────────────────
 # Helpers de output
@@ -692,65 +693,34 @@ ensure_host_paths "${ENV_FILE}"
 step "FASE 7 — GitHub Actions Runner"
 # ════════════════════════════════════════════════════════════════════════════
 
-# O runner pode estar em 4 estados ao re-executar o script:
-#   1. Nada instalado          → download + registro + serviço
-#   2. Binários extraídos      → pular download, fazer registro + serviço
-#   3. Registrado, sem serviço → pular download e registro, instalar serviço
-#   4. Tudo completo           → verificar status do serviço
-#
-# Indicadores:
-#   config.sh  — existe após extração do tarball (estado ≥ 2)
-#   .runner    — existe após config.sh --url/--token bem-sucedido (estado ≥ 3)
-#   svc.sh + systemd ativo — serviço instalado e rodando (estado 4)
+# Lógica idempotente delegada para o módulo _runner.sh (issue #51).
+# Estados detectados:
+#   N/A  - $RUNNER_DIR não existe        → cria, baixa, registra, instala, start
+#   1    - dir existe, binários ausentes → baixa, registra, instala, start
+#   2    - binários OK, .runner ausente  → registra, instala, start
+#   3    - .runner OK, systemd ausente   → instala, start
+#   4    - tudo presente                 → garante start (idempotente)
 
-# ── Estado 1: download necessário ─────────────────────────────────────────
-if [ ! -f "${RUNNER_DIR}/config.sh" ]; then
-    printf "  ${WHITE}Download do runner${NC}\n\n"
+# shellcheck source=scripts/deploy_server/_runner.sh
+source "${SPECIALISTS_DIR}/_runner.sh"
 
-    # Detectar arquitetura
-    ARCH=$(uname -m)
-    case "${ARCH}" in
-        x86_64)  RUNNER_ARCH="x64" ;;
-        aarch64) RUNNER_ARCH="arm64" ;;
-        *) fail "Arquitetura não suportada pelo runner: ${ARCH}" ;;
-    esac
-    info "Arquitetura: ${ARCH} → linux-${RUNNER_ARCH}"
+RUNNER_STATE=$(runner_get_state "${RUNNER_DIR}")
 
-    # Obter versão mais recente
-    info "Consultando versão mais recente do runner..."
-    RUNNER_VERSION=$(curl -fsSL \
-        "https://api.github.com/repos/actions/runner/releases/latest" \
-        | grep '"tag_name"' \
-        | sed 's/.*"v\([^"]*\)".*/\1/' \
-        | head -1)
+# Bootstrap incremental: N/A e 1 precisam de download.
+case "${RUNNER_STATE}" in
+    N/A|1)
+        printf "  ${WHITE}Download do runner${NC}\n\n"
+        runner_download_binaries "${RUNNER_DIR}" \
+            || fail "Falha no download do runner. Verifique conectividade com github.com."
+        RUNNER_STATE=2
+        ;;
+    *)
+        ok "Binários do runner presentes em ${RUNNER_DIR}"
+        ;;
+esac
 
-    if [ -z "${RUNNER_VERSION}" ]; then
-        fail "Não foi possível obter a versão do runner. Verifique a conectividade com github.com."
-    fi
-    info "Versão: ${RUNNER_VERSION}"
-
-    RUNNER_TARBALL_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz"
-
-    # Baixar e extrair
-    mkdir -p "${RUNNER_DIR}"
-    TARBALL="${RUNNER_DIR}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz"
-
-    info "Baixando runner em ${TARBALL}..."
-    if ! curl -fsSL --progress-bar -o "${TARBALL}" "${RUNNER_TARBALL_URL}"; then
-        rm -f "${TARBALL}"
-        fail "Falha ao baixar o runner. Verifique a conectividade."
-    fi
-
-    info "Extraindo em ${RUNNER_DIR}..."
-    tar xzf "${TARBALL}" -C "${RUNNER_DIR}"
-    rm -f "${TARBALL}"
-    ok "Runner extraído"
-else
-    ok "Binários do runner já extraídos em ${RUNNER_DIR}"
-fi
-
-# ── Estado 2: registro necessário ─────────────────────────────────────────
-if [ ! -f "${RUNNER_DIR}/.runner" ]; then
+# Estado 2 → 3: registro com URL + token interativo.
+if [ "${RUNNER_STATE}" = "2" ]; then
     printf "\n${WHITE}  Registro do runner no repositório GitHub${NC}\n\n"
     printf "  O token de registro é gerado em:\n"
     printf "  ${CYAN}Settings → Actions → Runners → New self-hosted runner${NC}\n\n"
@@ -767,35 +737,26 @@ if [ ! -f "${RUNNER_DIR}/.runner" ]; then
     printf "\n"
     [ -z "${REG_TOKEN}" ] && fail "Token de registro é obrigatório"
 
-    info "Registrando runner com label '${RUNNER_LABEL}'..."
-    if ! (cd "${RUNNER_DIR}" && ./config.sh \
-            --url "${REPO_URL}" \
-            --token "${REG_TOKEN}" \
-            --labels "${RUNNER_LABEL}" \
-            --name "${RUNNER_NAME}" \
-            --unattended \
-            --replace); then
-        fail "Falha ao registrar o runner. Verifique a URL e o token (tokens expiram após alguns minutos)."
-    fi
-    ok "Runner registrado: ${RUNNER_NAME} [${RUNNER_LABEL}]"
+    runner_register "${RUNNER_DIR}" "${REPO_URL}" "${REG_TOKEN}" "${RUNNER_NAME}" "${RUNNER_LABEL}" \
+        || fail "Falha ao registrar o runner. Verifique URL e token (tokens expiram em ~5min)."
+    RUNNER_STATE=3
 else
     ok "Runner já registrado em ${RUNNER_DIR}"
 fi
 
-# ── Estado 3: serviço systemd necessário ──────────────────────────────────
-RUNNER_SVC_STATUS=$(sudo "${RUNNER_DIR}/svc.sh" status 2>/dev/null || true)
-if echo "${RUNNER_SVC_STATUS}" | grep -qi "active\|running"; then
+# Estado 3 → 4: instala systemd unit.
+if [ "${RUNNER_STATE}" = "3" ]; then
+    runner_install_service "${RUNNER_DIR}" "${CURRENT_USER}" \
+        || fail "Falha ao instalar serviço systemd do runner."
+    RUNNER_STATE=4
+fi
+
+# Estado 4: garantir que o serviço está rodando.
+if runner_service_status_active "${RUNNER_DIR}"; then
     ok "Serviço do runner: ativo"
 else
-    # Serviço não ativo — instalar (se necessário) e iniciar
-    info "Instalando runner como serviço systemd (usuário: ${CURRENT_USER})..."
-    # svc.sh install é idempotente — se já instalado, apenas avisa
-    sudo bash -c "cd '${RUNNER_DIR}' && ./svc.sh install '${CURRENT_USER}'" 2>/dev/null || true
-
-    if ! sudo bash -c "cd '${RUNNER_DIR}' && ./svc.sh start"; then
-        fail "Falha ao iniciar o serviço do runner."
-    fi
-    ok "Serviço do runner instalado e iniciado"
+    runner_start_service "${RUNNER_DIR}" \
+        || fail "Falha ao iniciar o serviço do runner."
 fi
 
 # ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #51

## Summary

- Cria `scripts/deploy_server/_runner.sh` — biblioteca idempotente com 9 funções de detecção e 7 funções de ação para o GitHub Actions self-hosted runner. Single-source-of-truth para `siscan-server-setup.sh` (Fase 7) e `siscan-runner-recover.sh`.
- Refatora `siscan-server-setup.sh` Fase 7 — ~95 linhas viraram ~50 linhas que delegam pro módulo, mantendo idempotência por estado (N/A/1/2/3/4).
- Refatora `siscan-runner-recover.sh` — case ampliado de 3 ramos (A/A2/B+WARN) para 8 ramos (N/A/1/2/C/A/A2/B/WARN/OK/UNKNOWN). Novos cenários:
  - **N/A, 1, 2**: bootstrap incremental (recover instala do zero — antes redirecionava pro setup)
  - **C**: serviço systemd ausente, `.runner` válido — caminho cirúrgico sem token (caso real <HOST-DASHBOARD> 26/05/2026)
- Adiciona flag `--token TOKEN` no recover — sobrescreve prompt interativo nos cenários que precisam de token, habilita automação e cenário A2 defensivo.
- Atualiza `docs/siscan-server-doctor/scripts/siscan-runner-recover.md` com matriz de 10 cenários e seção "Relação com `siscan-server-setup.sh`".
- Atualiza `docs/DEPLOY_SERVER.md` Passo 4 do playbook refletindo a nova cobertura.

Diff:
- `+509 / -218` em 4 arquivos modificados + 1 novo (`_runner.sh`)

## Test plan

- [x] `bash -n` em `_runner.sh`, `siscan-server-setup.sh`, `siscan-runner-recover.sh` — sintaxe OK
- [x] Smoke-test das 10 funções de detecção em sub-shell isolado (source idempotente, runner_get_state cobrindo N/A/1/2/3, runner_local_age_days, runner_validate_*, runner_systemd_present, runner_query_api, runner_diagnose)
- [ ] Validação em VM real cobrindo:
  - [ ] Cenário **C** (caso da o operador): `sudo svc.sh stop && sudo svc.sh uninstall && bash siscan-runner-recover.sh` — esperado: install + start sem pedir token
  - [ ] Cenário **A** (matar `.runner` + roda recover com `--token <novo>`) — esperado: re-registro completo
  - [ ] Cenário **N/A** (`mv ~/actions-runner ~/actions-runner.bak && bash siscan-runner-recover.sh --token <novo>`) — esperado: bootstrap completo
  - [ ] Cenário **OK** (rodar em VM saudável) — esperado: exit 0 sem ação
  - [ ] Setup completo em VM nova: `bash siscan-server-setup.sh --product dashboard` — esperado: Fase 7 passa por N/A → 1 → 2 → 3 → 4 idempotente
- [x] Doc renderiza corretamente no GitHub (tabelas + cross-links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

