### PR TITLE
fix(runner): purgar .runner_migrated antes de config.sh --replace

### DIFF
--- a/scripts/deploy_server/_runner.sh
+++ b/scripts/deploy_server/_runner.sh
@@ -408,17 +408,35 @@ runner_uninstall_service() {
 #   em .service (marker da unit systemd — gerenciado por svc.sh install/uninstall).
 #
 #   Idempotente: silencioso quando arquivos já estão ausentes.
-#   Retorna 1 se .runner persistir em disco após a limpeza (caso raro de
-#   permissão/IO), permitindo fail-fast no caller.
+#   Retorna 1 se RUNNER_DIR vier vazio, ou se algum dos 5 artefatos persistir
+#   em disco após a limpeza (caso raro de permissão/IO), permitindo fail-fast
+#   no caller.
 runner_purge_local_config() {
     local dir="$1"
-    rm -f "$dir/.runner" \
-          "$dir/.runner_migrated" \
-          "$dir/.credentials" \
-          "$dir/.credentials_rsaparams" \
-          "$dir/.path"
-    if [ -e "$dir/.runner" ] || [ -e "$dir/.runner_migrated" ]; then
-        printf "ERRO: não foi possível remover .runner/.runner_migrated em %s — verifique permissões.\n" "$dir" >&2
+    # Guarda contra invocação sem RUNNER_DIR ou com path começando com "-"
+    # (rm interpretaria como flag): mensagem neutra, prefixo "ERRO:" é
+    # responsabilidade do fail() do caller.
+    if [ -z "$dir" ]; then
+        printf "runner_purge_local_config: RUNNER_DIR não informado\n" >&2
+        return 1
+    fi
+    # `--` impede que valores começando com `-` virem option para rm.
+    rm -f -- "$dir/.runner" \
+             "$dir/.runner_migrated" \
+             "$dir/.credentials" \
+             "$dir/.credentials_rsaparams" \
+             "$dir/.path"
+    # Verifica os 5 artefatos — contrato é "todos foram apagados",
+    # então qualquer resíduo (ex.: .path sem permissão) é falha.
+    local f leftover=""
+    for f in .runner .runner_migrated .credentials .credentials_rsaparams .path; do
+        if [ -e "$dir/$f" ]; then
+            leftover="${leftover:+$leftover, }$f"
+        fi
+    done
+    if [ -n "$leftover" ]; then
+        printf "não foi possível remover artefatos do runner em %s: %s — verifique permissões.\n" \
+            "$dir" "$leftover" >&2
         return 1
     fi
     return 0

--- a/scripts/deploy_server/_runner.sh
+++ b/scripts/deploy_server/_runner.sh
@@ -393,14 +393,46 @@ runner_uninstall_service() {
     fi
 }
 
+# runner_purge_local_config RUNNER_DIR
+#   Apaga TODOS os artefatos locais de configuração do runner que podem
+#   ser lidos pelo Runner.Listener como "ainda configurado". Lista
+#   exaustiva (5 arquivos):
+#     - .runner                — config principal (agentId, gitHubUrl, serverUrl)
+#     - .runner_migrated       — cópia gerada por auto-update (≥ 2.334 lê como
+#                                evidência de "configurado" se .runner sumiu)
+#     - .credentials           — JWT do runner
+#     - .credentials_rsaparams — chave RSA para rotação de credenciais
+#     - .path                  — work folder path (lixo residual após uninstall)
+#
+#   NÃO toca em .env (variáveis persistidas via setup, ex.: COMPOSE_DIR) nem
+#   em .service (marker da unit systemd — gerenciado por svc.sh install/uninstall).
+#
+#   Idempotente: silencioso quando arquivos já estão ausentes.
+#   Retorna 1 se .runner persistir em disco após a limpeza (caso raro de
+#   permissão/IO), permitindo fail-fast no caller.
+runner_purge_local_config() {
+    local dir="$1"
+    rm -f "$dir/.runner" \
+          "$dir/.runner_migrated" \
+          "$dir/.credentials" \
+          "$dir/.credentials_rsaparams" \
+          "$dir/.path"
+    if [ -e "$dir/.runner" ] || [ -e "$dir/.runner_migrated" ]; then
+        printf "ERRO: não foi possível remover .runner/.runner_migrated em %s — verifique permissões.\n" "$dir" >&2
+        return 1
+    fi
+    return 0
+}
+
 # runner_remove_registration RUNNER_DIR OWNER REPO
 #   Remove o registro do runner em três camadas, de cima pra baixo:
 #     1. Se o runner já não existe remotamente (total_count=0), pula
 #        config.sh remove — não há nada a desregistrar no GitHub.
 #     2. Caso contrário, tenta obter remove-token via API (endpoint distinto
 #        do registration-token) e usa ./config.sh remove --token <remove>.
-#     3. Sempre encerra com `rm -f` dos arquivos locais de registro
-#        (.runner, .credentials, .credentials_rsaparams). Idempotente.
+#     3. Sempre encerra com `runner_purge_local_config` — apaga os 5
+#        artefatos locais (.runner, .runner_migrated, .credentials,
+#        .credentials_rsaparams, .path).
 #   Sem este fallback determinístico, registration-token passado a
 #   config.sh remove falha em silêncio e deixa .runner órfão — quebra
 #   o cenário A/A2 do recover com "Cannot configure the runner because it
@@ -449,13 +481,12 @@ runner_remove_registration() {
         fi
     fi
 
-    # Camada 3: limpeza local determinística (sempre executada)
-    rm -f "$dir/.runner" "$dir/.credentials" "$dir/.credentials_rsaparams"
-    if [ -f "$dir/.runner" ]; then
-        printf "ERRO: não foi possível remover %s/.runner — verifique permissões.\n" "$dir" >&2
-        return 1
-    fi
-    ok "Registro local removido (.runner + .credentials*)"
+    # Camada 3: limpeza local determinística (sempre executada).
+    # Inclui .runner_migrated (cópia gerada por auto-update do runner que,
+    # se permanecer, faz config.sh --replace falhar com "already configured")
+    # e .path (resíduo de svc.sh uninstall). Ver runner_purge_local_config.
+    runner_purge_local_config "$dir" || return 1
+    ok "Registro local removido (.runner + .runner_migrated + .credentials* + .path)"
 }
 
 # runner_service_status_active RUNNER_DIR

--- a/siscan-runner-recover.sh
+++ b/siscan-runner-recover.sh
@@ -318,7 +318,15 @@ case "$scenario" in
         ;;
 
     2)
-        # Binários presentes, .runner ausente
+        # Binários presentes, .runner ausente.
+        # Pré-purge: o runner_get_state olha só .runner, mas auto-update
+        # cria .runner_migrated (cópia 1:1 do .runner). Se .runner_migrated
+        # persistir, config.sh --unattended --replace falha com "already
+        # configured" porque o Runner.Listener lê o migrated como evidência
+        # de configuração ativa. Purge é idempotente — seguro mesmo quando
+        # os artefatos já estão ausentes.
+        runner_purge_local_config "$RUNNER_DIR" \
+            || fail "Falha ao limpar artefatos residuais (.runner_migrated/.path) — verifique permissões em $RUNNER_DIR."
         prompt_token_if_needed
         runner_register "$RUNNER_DIR" "$REPO_URL" "$TOKEN" "$EXPECTED_NAME" "$RUNNER_LABEL" \
             || fail "Falha ao registrar o runner."

--- a/siscan-server-setup.sh
+++ b/siscan-server-setup.sh
@@ -721,6 +721,14 @@ esac
 
 # Estado 2 → 3: registro com URL + token interativo.
 if [ "${RUNNER_STATE}" = "2" ]; then
+    # Pré-purge defensiva: runner_get_state olha só .runner, mas auto-update
+    # cria .runner_migrated (cópia 1:1 do .runner). Se .runner_migrated
+    # persistir, config.sh --unattended --replace falha com "already
+    # configured". Cenário possível em reinstalação (volume reaproveitado).
+    # Idempotente — seguro mesmo numa instalação greenfield.
+    runner_purge_local_config "${RUNNER_DIR}" \
+        || fail "Falha ao limpar artefatos residuais (.runner_migrated/.path) — verifique permissões em ${RUNNER_DIR}."
+
     printf "\n${WHITE}  Registro do runner no repositório GitHub${NC}\n\n"
     printf "  O token de registro é gerado em:\n"
     printf "  ${CYAN}Settings → Actions → Runners → New self-hosted runner${NC}\n\n"

--- a/tests/unit/test_runner_remove_registration.bats
+++ b/tests/unit/test_runner_remove_registration.bats
@@ -275,9 +275,30 @@ teardown() {
     [ ! -f "${RUNNER_DIR}/.runner_migrated" ]
 }
 
+@test "runner_purge_local_config: RUNNER_DIR vazio retorna 1 (guarda contra option injection)" {
+    # Revisão Copilot PR #69: dir vazio em rm -f sem `--` poderia interpretar
+    # próximos args como flags. A guarda explícita curto-circuita antes.
+    run runner_purge_local_config ""
+    assert_failure
+    assert_output --partial "RUNNER_DIR não informado"
+}
+
+@test "runner_purge_local_config: falha de IO em .path também é detectada (contrato 5 arquivos)" {
+    # Revisão Copilot PR #69: header diz "purga 5 artefatos"; antes só .runner
+    # e .runner_migrated eram checados — .path/.credentials* falhando
+    # silenciosamente retornava 0. Agora os 5 são verificados.
+    rm() { :; }
+    export -f rm
+
+    [ -f "${RUNNER_DIR}/.path" ]
+    run runner_purge_local_config "${RUNNER_DIR}"
+    assert_failure
+    assert_output --partial ".path"
+}
+
 @test "runner_purge_local_config: falha de IO em .runner_migrated retorna 1" {
     # Override de rm como no-op: simula falha de permissão/IO. A função
-    # deve detectar via `[ -e ... ]` e retornar 1 em vez de silenciar.
+    # deve detectar e retornar 1 em vez de silenciar.
     rm() { :; }
     export -f rm
 

--- a/tests/unit/test_runner_remove_registration.bats
+++ b/tests/unit/test_runner_remove_registration.bats
@@ -6,8 +6,13 @@
 #   2. Remove-token API — runner remoto presente + credencial disponível.
 #   3. Fallback local   — sem credencial ou config.sh remove falhou.
 #
-# A camada 3 (rm -f dos arquivos locais) é exercida em todos os cenários:
-# .runner + .credentials + .credentials_rsaparams devem terminar ausentes.
+# A camada 3 delega para runner_purge_local_config e deve deixar todos os
+# 5 artefatos locais ausentes:
+#   .runner, .runner_migrated, .credentials, .credentials_rsaparams, .path
+#
+# .runner_migrated (lab #220 — 2026-05-27): cópia gerada por auto-update do
+# runner que, quando .runner é removido manualmente, segura o flag "já
+# configurado" do Runner.Listener e faz config.sh --replace falhar.
 
 load '../test_helper/bats-support/load'
 load '../test_helper/bats-assert/load'
@@ -23,11 +28,14 @@ setup() {
     # Source da biblioteca sob teste
     source "${BATS_TEST_DIRNAME}/../../scripts/deploy_server/_runner.sh"
 
-    # Diretório de runner sintético com os 3 arquivos do registro local
+    # Diretório de runner sintético com os 5 arquivos do registro local
+    # (inclui .runner_migrated e .path — ver runner_purge_local_config)
     RUNNER_DIR="$(mktemp -d)"
     touch "${RUNNER_DIR}/.runner" \
+          "${RUNNER_DIR}/.runner_migrated" \
           "${RUNNER_DIR}/.credentials" \
-          "${RUNNER_DIR}/.credentials_rsaparams"
+          "${RUNNER_DIR}/.credentials_rsaparams" \
+          "${RUNNER_DIR}/.path"
     # Stub do config.sh — registra args recebidos em $CONFIG_LOG e fail/pass
     # controlados por CONFIG_REMOVE_EXIT (default 0)
     CONFIG_LOG="$(mktemp)"
@@ -61,8 +69,10 @@ teardown() {
     assert_success
 
     [ ! -f "${RUNNER_DIR}/.runner" ]
+    [ ! -f "${RUNNER_DIR}/.runner_migrated" ]
     [ ! -f "${RUNNER_DIR}/.credentials" ]
     [ ! -f "${RUNNER_DIR}/.credentials_rsaparams" ]
+    [ ! -f "${RUNNER_DIR}/.path" ]
     # config.sh remove não deve ter sido invocado
     [ ! -s "${CONFIG_LOG}" ]
 }
@@ -85,8 +95,10 @@ teardown() {
     grep -q '^AAAAREMOVETOKENBBBB$' "${CONFIG_LOG}"
     # Limpeza local mantida (camada 3 sempre executa)
     [ ! -f "${RUNNER_DIR}/.runner" ]
+    [ ! -f "${RUNNER_DIR}/.runner_migrated" ]
     [ ! -f "${RUNNER_DIR}/.credentials" ]
     [ ! -f "${RUNNER_DIR}/.credentials_rsaparams" ]
+    [ ! -f "${RUNNER_DIR}/.path" ]
 }
 
 @test "Camada 2: config.sh remove falha — fallback local ainda limpa arquivos" {
@@ -101,8 +113,10 @@ teardown() {
     grep -q '^remove$' "${CONFIG_LOG}"
     # E os arquivos locais foram removidos no fallback
     [ ! -f "${RUNNER_DIR}/.runner" ]
+    [ ! -f "${RUNNER_DIR}/.runner_migrated" ]
     [ ! -f "${RUNNER_DIR}/.credentials" ]
     [ ! -f "${RUNNER_DIR}/.credentials_rsaparams" ]
+    [ ! -f "${RUNNER_DIR}/.path" ]
 }
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -120,8 +134,10 @@ teardown() {
     [ ! -s "${CONFIG_LOG}" ]
     # Mas limpeza local ocorreu
     [ ! -f "${RUNNER_DIR}/.runner" ]
+    [ ! -f "${RUNNER_DIR}/.runner_migrated" ]
     [ ! -f "${RUNNER_DIR}/.credentials" ]
     [ ! -f "${RUNNER_DIR}/.credentials_rsaparams" ]
+    [ ! -f "${RUNNER_DIR}/.path" ]
 }
 
 @test "Camada 3: remote presente mas sem credencial pra remove-token — limpa local" {
@@ -145,8 +161,10 @@ teardown() {
     export -f runner_query_api runner_get_remove_token
 
     rm -f "${RUNNER_DIR}/.runner" \
+          "${RUNNER_DIR}/.runner_migrated" \
           "${RUNNER_DIR}/.credentials" \
-          "${RUNNER_DIR}/.credentials_rsaparams"
+          "${RUNNER_DIR}/.credentials_rsaparams" \
+          "${RUNNER_DIR}/.path"
 
     run runner_remove_registration "${RUNNER_DIR}" "owner" "repo"
     assert_success
@@ -183,8 +201,88 @@ teardown() {
     run runner_remove_registration "${RUNNER_DIR}" "owner" "repo"
     assert_success
     [ ! -f "${RUNNER_DIR}/.runner" ]
+    [ ! -f "${RUNNER_DIR}/.runner_migrated" ]
     [ ! -f "${RUNNER_DIR}/.credentials" ]
     [ ! -f "${RUNNER_DIR}/.credentials_rsaparams" ]
+    [ ! -f "${RUNNER_DIR}/.path" ]
     # E config.sh remove (que falharia com registration-token) não foi chamado
     [ ! -s "${CONFIG_LOG}" ]
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# runner_purge_local_config — função standalone (lab #220 — 2026-05-27)
+# ────────────────────────────────────────────────────────────────────────────
+
+@test "runner_purge_local_config: remove os 5 artefatos locais" {
+    # Pré-condição: os 5 arquivos existem (criados em setup)
+    [ -f "${RUNNER_DIR}/.runner" ]
+    [ -f "${RUNNER_DIR}/.runner_migrated" ]
+    [ -f "${RUNNER_DIR}/.credentials" ]
+    [ -f "${RUNNER_DIR}/.credentials_rsaparams" ]
+    [ -f "${RUNNER_DIR}/.path" ]
+
+    run runner_purge_local_config "${RUNNER_DIR}"
+    assert_success
+
+    [ ! -f "${RUNNER_DIR}/.runner" ]
+    [ ! -f "${RUNNER_DIR}/.runner_migrated" ]
+    [ ! -f "${RUNNER_DIR}/.credentials" ]
+    [ ! -f "${RUNNER_DIR}/.credentials_rsaparams" ]
+    [ ! -f "${RUNNER_DIR}/.path" ]
+}
+
+@test "runner_purge_local_config: idempotente — diretório já limpo retorna 0" {
+    rm -f "${RUNNER_DIR}/.runner" \
+          "${RUNNER_DIR}/.runner_migrated" \
+          "${RUNNER_DIR}/.credentials" \
+          "${RUNNER_DIR}/.credentials_rsaparams" \
+          "${RUNNER_DIR}/.path"
+
+    run runner_purge_local_config "${RUNNER_DIR}"
+    assert_success
+}
+
+@test "runner_purge_local_config: preserva .env e .service (não toca em config persistido)" {
+    # .env carrega COMPOSE_DIR e flags do setup; .service é marker do
+    # systemd unit gerenciado por svc.sh. Nenhum dos dois pode ser apagado
+    # pela função (sob pena de quebrar o próximo run do recover/setup).
+    echo "COMPOSE_DIR=/srv/foo" > "${RUNNER_DIR}/.env"
+    echo "actions.runner.foo.service" > "${RUNNER_DIR}/.service"
+
+    run runner_purge_local_config "${RUNNER_DIR}"
+    assert_success
+
+    [ -f "${RUNNER_DIR}/.env" ]
+    [ -f "${RUNNER_DIR}/.service" ]
+    # Conteúdo intacto
+    grep -q "COMPOSE_DIR=/srv/foo" "${RUNNER_DIR}/.env"
+    grep -q "actions.runner.foo.service" "${RUNNER_DIR}/.service"
+}
+
+@test "runner_purge_local_config: cenário lab #220 — só .runner_migrated impede config.sh --replace" {
+    # Reproduz a situação real do lab: operadora apagou manualmente .runner
+    # + .credentials*, mas .runner_migrated (gerado por auto-update) ficou
+    # e fez config.sh --replace falhar com "already configured".
+    # Após o purge, o diretório fica de fato limpo pra novo register.
+    rm -f "${RUNNER_DIR}/.runner" \
+          "${RUNNER_DIR}/.credentials" \
+          "${RUNNER_DIR}/.credentials_rsaparams"
+    # .runner_migrated permanece — esse é o ponto da regressão
+    [ -f "${RUNNER_DIR}/.runner_migrated" ]
+
+    run runner_purge_local_config "${RUNNER_DIR}"
+    assert_success
+    [ ! -f "${RUNNER_DIR}/.runner_migrated" ]
+}
+
+@test "runner_purge_local_config: falha de IO em .runner_migrated retorna 1" {
+    # Override de rm como no-op: simula falha de permissão/IO. A função
+    # deve detectar via `[ -e ... ]` e retornar 1 em vez de silenciar.
+    rm() { :; }
+    export -f rm
+
+    [ -f "${RUNNER_DIR}/.runner_migrated" ]
+
+    run runner_purge_local_config "${RUNNER_DIR}"
+    assert_failure
 }


### PR DESCRIPTION
## Resumo

Destrava cenário operacional onde `config.sh --unattended --replace` falha com **"already configured"** mesmo após o operador apagar manualmente `.runner` + `.credentials*`.

Causa raiz: o auto-update do GitHub Actions runner (≥ 2.334) gera `.runner_migrated` — cópia 1:1 do `.runner`. Quando `.runner` é removido manualmente, `.runner_migrated` persiste e o Runner.Listener trata como configuração ativa.

## O que muda

- **Nova função `runner_purge_local_config`** em `scripts/deploy_server/_runner.sh` — apaga os 5 artefatos locais (`.runner`, `.runner_migrated`, `.credentials`, `.credentials_rsaparams`, `.path`) preservando `.env` e `.service`. Idempotente.

- **`runner_remove_registration`** — Camada 3 agora delega para a nova função (antes apagava só 3 arquivos inline).

- **`siscan-runner-recover.sh` ramo 2** (binários OK + `.runner` ausente) — chama purga como pré-step antes de `runner_register`.

- **`siscan-server-setup.sh` ramo 2** (`RUNNER_STATE=2`) — idem, alinhamento simétrico para reinstalações com volume reaproveitado.

- **5 testes bats novos** em `tests/unit/test_runner_remove_registration.bats` cobrindo a função standalone (purga 5 arquivos, idempotência, preservação de `.env`/`.service`, cenário operacional do lab e falha de IO).

## Por que adoção em setup + recover

`_runner.sh` é o módulo compartilhado. Tanto setup quanto recover dão `source` nele e ambos têm o mesmo ramo `RUNNER_STATE=2` chamando `runner_register` direto. Sem a purga em ambos, o fix fica assimétrico e o gap reaparece em reinstalações.

Divisão de responsabilidades preservada: setup continua sendo "provisiona VM do zero", recover continua "remedia runner em VM já provisionada", a lógica comum vive em `_runner.sh`.

## Test plan

- [x] `./tests/bats/bin/bats tests/unit/` — **90/90 verde** (13/13 em `test_runner_remove_registration.bats`, incluindo 5 testes novos)
- [ ] Operação manual em VM-alvo: `git pull origin main` + `bash siscan-runner-recover.sh --token <NEW_TOKEN>` em diretório com `.runner_migrated` órfão; esperado destrave automático sem `rm -f` manual
- [ ] Validar `gh api repos/<owner>/<repo>/actions/runners --jq '.total_count'` retorna `1` após o recover

🤖 Generated with [Claude Code](https://claude.com/claude-code)