### PR TITLE
feat(TSK00.05.01): mover derivação HOST_SECRETS_DIR/HOST_BACKUPS_DIR para setup Fase 5

### DIFF
--- a/docs/guides/siscan-server-doctor/products-manifest.md
+++ b/docs/guides/siscan-server-doctor/products-manifest.md
@@ -6,7 +6,7 @@ Fonte de verdade declarativa que descreve cada produto que o assistente deploya.
 
 ```json
 {
-  "version": "1.0",
+  "version": "2.0",
   "products": {
     "<id>": {
       "label": "Nome amigável",
@@ -20,7 +20,18 @@ Fonte de verdade declarativa que descreve cada produto que o assistente deploya.
       "expected_services": ["app", "..."],
       "expected_external_ports": [5001],
       "required_env_vars": ["DATABASE_HOST", "..."],
-      "host_dir_vars": ["HOST_LOG_DIR", "..."],
+      "host_dir_vars": [
+        "HOST_LOG_DIR",
+        "...",
+        {
+          "name": "HOST_SECRETS_DIR",
+          "derived_from": "HOST_LOG_DIR",
+          "derivation": "dirname + /secrets",
+          "default_mode": "700",
+          "auto_create": true,
+          "description": "..."
+        }
+      ],
       "default_passwords_to_detect": ["siscan_rpa"],
       "extras": {
         "rsa_keys_required": true,
@@ -37,6 +48,30 @@ Fonte de verdade declarativa que descreve cada produto que o assistente deploya.
 }
 ```
 
+### `host_dir_vars` — schema v2.0 (TSK00.05.01 [#95](https://github.com/Prisma-Consultoria/assistente-siscan-rpa/issues/95))
+
+A partir da v2.0, `host_dir_vars[]` aceita DUAS formas que coexistem no mesmo array:
+
+| Forma | Quem preenche | Quem valida |
+|---|---|---|
+| **String** (legado) | Operador no setup Fase 5 (prompt interativo) | `check-env` (não-vazia + path Linux) + `check-permissions` (existe + escrevível) |
+| **Objeto** (v2.0) | `siscan-server-setup.sh` Fase 5 deriva automaticamente | `check-permissions` via blocos dedicados (extras-driven) |
+
+**Schema do objeto**:
+
+| Campo | Tipo | Obrigatório | Descrição |
+|---|---|---|---|
+| `name` | string | sim | Nome da variável (ex: `HOST_SECRETS_DIR`) |
+| `derived_from` | string | sim | Variável-fonte para derivação (ex: `HOST_LOG_DIR`) |
+| `derivation` | string | sim | Operação de derivação. Suportada: `"dirname + /<subdir>"` — extrai parent de `derived_from` e anexa subdir. |
+| `default_mode` | string | não | Permissões POSIX (ex: `"700"` para secrets). Aplicado via `chmod` após `mkdir -p`. |
+| `auto_create` | boolean | não (default `false`) | Se `true`, setup cria o diretório via `mkdir -p`. |
+| `description` | string | não | Descrição amigável (para help). |
+
+**Semântica de preservação**: se o operador declarar manualmente o valor no `.env` (ex: `HOST_SECRETS_DIR=/mnt/seguro/keys`), o setup **preserva** esse valor — apenas garante que o diretório exista e tenha o `default_mode` correto. Já com `HOST_SECRETS_DIR` ausente, é derivado de `dirname(HOST_LOG_DIR) + /secrets`.
+
+**Backward compat para `product_get_array host_dir_vars`**: a função emite **somente strings** — objetos são filtrados pra preservar a semântica histórica ("vars que o operador precisa declarar"). Para acessar metadata de derivação, use `product_get_host_dir_vars_derived`.
+
 ## Campos
 
 | Campo | Tipo | Quem consome | Para quê |
@@ -52,7 +87,7 @@ Fonte de verdade declarativa que descreve cada produto que o assistente deploya.
 | `expected_services` | array | `check-stack` | Serviços que devem estar `running` no `docker compose ps` |
 | `expected_external_ports` | array | `check-stack` | Portas externas verificadas contra collision (`ss -tlnp`) |
 | `required_env_vars` | array | `check-env` | Variáveis obrigatórias no `.env` (validadas não-vazias + regras especiais) |
-| `host_dir_vars` | array | `check-env`, `check-permissions` | `HOST_*_DIR` declarados no `.env` (existência + escrita) |
+| `host_dir_vars` | array misto (string \| objeto, schema v2.0) | `check-env`, `check-permissions`, `siscan-server-setup` Fase 5 | `HOST_*_DIR`. Strings: operador declara, specialists validam. Objetos: setup deriva automaticamente (TSK00.05.01) — ver subseção dedicada acima |
 | `default_passwords_to_detect` | array | `check-env` | Valores de `DATABASE_PASSWORD` que indicam senha default não alterada |
 | `extras` | object | múltiplos | Flags booleanas + defaults consumidos por specialists específicos |
 

--- a/scripts/data/products.json
+++ b/scripts/data/products.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "2.0",
   "description": "Manifesto declarativo dos produtos que o assistente deploya. Cada specialist em scripts/deploy_server/check-*.sh lê dessa fonte em vez de hardcodar 'case \"$SISCAN_PRODUCT\"'.",
   "schema": {
     "label": "Nome amigável do produto",
@@ -13,7 +13,15 @@
     "expected_services": "Serviços do compose que devem estar 'running' (migrate não conta)",
     "expected_external_ports": "Portas externas publicadas no host (verificadas por collision)",
     "required_env_vars": "Variáveis obrigatórias no .env (check-env valida não-vazias)",
-    "host_dir_vars": "Variáveis HOST_*_DIR que precisam existir + ser escrevíveis",
+    "host_dir_vars": "Variáveis HOST_*_DIR. Aceita STRING (forma legada: variável obrigatória, declarada pelo operador) OU OBJETO {name, derived_from, derivation, default_mode, auto_create, description} para variáveis derivadas automaticamente pelo setup Fase 5 (TSK00.05.01).",
+    "host_dir_vars_object_schema": {
+      "name": "Nome da variável (ex: HOST_SECRETS_DIR)",
+      "derived_from": "Variável-fonte para derivação (ex: HOST_LOG_DIR)",
+      "derivation": "Operação de derivação. Suportada: 'dirname + /<subdir>' (extrai parent dir de derived_from e anexa subdir).",
+      "default_mode": "Permissões POSIX (ex: '700' para secrets). Opcional.",
+      "auto_create": "Se true, o setup cria o diretório (mkdir -p) na Fase 5. Default false.",
+      "description": "Descrição amigável para exibir no setup interativo."
+    },
     "default_passwords_to_detect": "Valores de DATABASE_PASSWORD que indicam senha não alterada",
     "extras": "Flags booleanas + defaults consumidos por specialists específicos"
   },
@@ -42,7 +50,22 @@
         "HOST_SISCAN_REPORTS_INPUT_DIR",
         "HOST_REPORTS_OUTPUT_CONSOLIDATED_DIR",
         "HOST_REPORTS_OUTPUT_CONSOLIDATED_PDFS_DIR",
-        "HOST_CONFIG_DIR"
+        "HOST_CONFIG_DIR",
+        {
+          "name": "HOST_SECRETS_DIR",
+          "derived_from": "HOST_LOG_DIR",
+          "derivation": "dirname + /secrets",
+          "default_mode": "700",
+          "auto_create": true,
+          "description": "Diretório de chaves RSA + credenciais SISCAN cifradas — derivado automaticamente do parent de HOST_LOG_DIR se não declarado (TSK00.05.01)"
+        },
+        {
+          "name": "HOST_BACKUPS_DIR",
+          "derived_from": "HOST_LOG_DIR",
+          "derivation": "dirname + /backups",
+          "auto_create": true,
+          "description": "Diretório de backups (dumps do banco) — derivado automaticamente do parent de HOST_LOG_DIR se não declarado (TSK00.05.01)"
+        }
       ],
       "default_passwords_to_detect": ["siscan_rpa"],
       "extras": {
@@ -110,7 +133,22 @@
         "HOST_SISCAN_REPORTS_INPUT_DIR",
         "HOST_REPORTS_OUTPUT_CONSOLIDATED_DIR",
         "HOST_REPORTS_OUTPUT_CONSOLIDATED_PDFS_DIR",
-        "HOST_CONFIG_DIR"
+        "HOST_CONFIG_DIR",
+        {
+          "name": "HOST_SECRETS_DIR",
+          "derived_from": "HOST_LOG_DIR",
+          "derivation": "dirname + /secrets",
+          "default_mode": "700",
+          "auto_create": true,
+          "description": "Diretório de chaves RSA + credenciais SISCAN cifradas — derivado automaticamente do parent de HOST_LOG_DIR se não declarado (TSK00.05.01)"
+        },
+        {
+          "name": "HOST_BACKUPS_DIR",
+          "derived_from": "HOST_LOG_DIR",
+          "derivation": "dirname + /backups",
+          "auto_create": true,
+          "description": "Diretório de backups (dumps do banco) — derivado automaticamente do parent de HOST_LOG_DIR se não declarado (TSK00.05.01)"
+        }
       ],
       "default_passwords_to_detect": ["siscan_rpa", "siscan_dashboard"],
       "extras": {

--- a/scripts/deploy_server/_common.sh
+++ b/scripts/deploy_server/_common.sh
@@ -419,9 +419,56 @@ product_get() {
 
 # product_get_array FIELD
 #   Emite cada elemento do array em linha separada (use com mapfile/<<<).
+#
+#   Tratamento especial para `host_dir_vars` (schema v2.0, TSK00.05.01):
+#   o array pode misturar strings (forma legada — variáveis obrigatórias,
+#   declaradas pelo operador) e objetos (forma nova — variáveis derivadas
+#   automaticamente pelo setup, opcionais para o operador).
+#
+#   Para preservar a SEMÂNTICA HISTÓRICA de `host_dir_vars` ("vars que precisam
+#   estar declaradas no .env, validadas por check-env/check-permissions"),
+#   esta função emite SOMENTE STRINGS — objetos são filtrados. Consumidores
+#   que precisam da metadata de derivação devem usar
+#   `product_get_host_dir_vars_derived` (que retorna SOMENTE os objetos).
+#
+#   Razão de design: check-env hoje falha se uma var de `host_dir_vars` está
+#   vazia no .env. Se HOST_SECRETS_DIR/HOST_BACKUPS_DIR (objetos derivados)
+#   entrassem aqui, VMs com .env pre-TSK00.05.01 (workflow CD derivava
+#   inline) ganhariam falsos FAILs até re-rodar setup. Manter os objetos
+#   fora deste loop preserva a transição não-disruptiva.
 product_get_array() {
     local field="$1"
-    jq -r ".products.\"$SISCAN_PRODUCT\".$field[]?" "$PRODUCTS_FILE" 2>/dev/null
+    if [ "$field" = "host_dir_vars" ]; then
+        # Schema v2.0: emite só strings (forma legada). Objetos derivados
+        # vão por product_get_host_dir_vars_derived.
+        jq -r ".products.\"$SISCAN_PRODUCT\".$field[]? | select(type == \"string\")" "$PRODUCTS_FILE" 2>/dev/null
+    else
+        jq -r ".products.\"$SISCAN_PRODUCT\".$field[]?" "$PRODUCTS_FILE" 2>/dev/null
+    fi
+}
+
+# product_get_host_dir_vars_derived
+#   Emite, em formato TSV "name<TAB>derived_from<TAB>derivation<TAB>default_mode<TAB>auto_create<TAB>description",
+#   uma linha por elemento OBJETO de `host_dir_vars` (TSK00.05.01).
+#   Strings da forma legada são IGNORADAS — esta função só retorna metadata
+#   de variáveis com derivação automática declarada.
+#
+#   Uso (Fase 5 do siscan-server-setup.sh):
+#     while IFS=$'\t' read -r name derived_from derivation mode auto_create _desc; do
+#       env_set_or_derive "$name" "$derived_from" "$derivation" "$mode" "$auto_create"
+#     done < <(product_get_host_dir_vars_derived)
+#
+#   Saída vazia para produtos cujo `host_dir_vars` é só strings (ex: dashboard).
+product_get_host_dir_vars_derived() {
+    # Importante: bash `read -r` com IFS=$'\t' COLAPSA tabs adjacentes (IFS é
+    # whitespace-only). Para preservar campos vazios (default_mode opcional),
+    # emitimos o sentinela "-" no lugar de strings vazias — o caller troca
+    # de volta para vazio antes de usar. Alternativa seria usar separador
+    # não-whitespace, mas | poderia colidir com paths.
+    jq -r '.products."'"$SISCAN_PRODUCT"'".host_dir_vars[]?
+        | select(type == "object")
+        | [.name, .derived_from, .derivation, (if (.default_mode // "") == "" then "-" else .default_mode end), (.auto_create // false | tostring), (.description // "-")]
+        | @tsv' "$PRODUCTS_FILE" 2>/dev/null
 }
 
 # product_has_extra KEY

--- a/siscan-server-setup.sh
+++ b/siscan-server-setup.sh
@@ -68,6 +68,11 @@ RUNNER_DIR="${RUNNER_DIR:-${HOME}/actions-runner}"
 CURRENT_USER="$(whoami)"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SPECIALISTS_DIR="${SCRIPT_DIR}/scripts/deploy_server"
+# Manifesto declarativo de produtos — usado por ensure_host_paths_derived
+# (TSK00.05.01) para iterar variáveis com derivação automática (HOST_SECRETS_DIR,
+# HOST_BACKUPS_DIR). Consumidores em scripts/deploy_server/check-*.sh já usam
+# o mesmo PRODUCTS_FILE — manter consistente.
+PRODUCTS_FILE="${PRODUCTS_FILE:-${SCRIPT_DIR}/scripts/data/products.json}"
 
 # ────────────────────────────────────────────────────────────────────────────
 # Helpers de output — sourcing _common.sh (TSK00.04.13 #92)
@@ -204,6 +209,134 @@ ensure_host_paths() {
     done
 
     return ${failed}
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# env_apply_derivation DERIVATION PARENT_VAL → stdout
+# Aplica uma expressão de derivação declarada no manifesto products.json
+# (campo host_dir_vars[].derivation) a um valor pai.
+#
+# Suporta atualmente a única expressão usada em produção (TSK00.05.01):
+#   "dirname + /<subdir>"   →  $(dirname PARENT_VAL)/<subdir>
+#
+# Expressões desconhecidas retornam vazio (caller deve checar). Adicionar
+# novas formas exige só estender este switch — o consumidor não muda.
+# ────────────────────────────────────────────────────────────────────────────
+env_apply_derivation() {
+    local derivation="${1}" parent_val="${2}"
+    [ -z "${parent_val}" ] && return 0
+
+    case "${derivation}" in
+        "dirname + "/*)
+            # "dirname + /secrets" → /<dirname parent>/secrets
+            local subdir="${derivation#dirname + }"
+            printf '%s%s' "$(dirname "${parent_val}")" "${subdir}"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# env_set_or_derive ENV_FILE VAR_NAME PARENT_VAR DERIVATION [DEFAULT_MODE] [AUTO_CREATE]
+#
+# Idempotente. Garante que VAR_NAME esteja presente no ENV_FILE e que o
+# diretório correspondente exista com as permissões corretas.
+#
+#   - Se VAR_NAME já tem valor no .env: PRESERVA o valor (operador no
+#     comando). Apenas cria o diretório (se AUTO_CREATE=true) e aplica
+#     DEFAULT_MODE (se especificado) — preservando customizações.
+#   - Se VAR_NAME está ausente/vazio: deriva via DERIVATION a partir do
+#     valor de PARENT_VAR (também lido do .env). Grava o valor derivado
+#     no .env, cria o diretório, aplica DEFAULT_MODE.
+#   - Se PARENT_VAR também está vazio: pula (warn) — operador precisa
+#     preencher PARENT_VAR antes.
+#
+# Retorna 0 em sucesso, 1 em falha de criação/chmod, 2 em erro de uso.
+#
+# Esta função é parte do contrato consolidado da TSK00.05.01 (#95) —
+# Workflows CD downstream (siscan-rpa #694, siscan-dashboard #525)
+# REMOVEM o step inline "Garantir HOST_SECRETS_DIR e HOST_BACKUPS_DIR"
+# e confiam que o setup já entregou essas variáveis no .env.
+# ────────────────────────────────────────────────────────────────────────────
+env_set_or_derive() {
+    local env_file="${1}" var_name="${2}" parent_var="${3}" derivation="${4}"
+    local default_mode="${5:-}" auto_create="${6:-true}"
+
+    [ -z "${env_file}" ] || [ -z "${var_name}" ] || [ -z "${parent_var}" ] || [ -z "${derivation}" ] && return 2
+
+    local current parent val
+    current="$(_read_env_value "${env_file}" "${var_name}")"
+
+    if [ -n "${current}" ]; then
+        # Preservar valor existente — operador já configurou.
+        val="${current}"
+        ok "${var_name}=${val} (preservado do .env)"
+    else
+        # Derivar a partir do parent.
+        parent="$(_read_env_value "${env_file}" "${parent_var}")"
+        if [ -z "${parent}" ]; then
+            warn "${var_name} não pode ser derivado: ${parent_var} também está vazio no .env"
+            return 1
+        fi
+        val="$(env_apply_derivation "${derivation}" "${parent}")"
+        if [ -z "${val}" ]; then
+            warn "${var_name} não pode ser derivado: expressão '${derivation}' não reconhecida"
+            return 1
+        fi
+        _set_env_value "${env_file}" "${var_name}" "${val}"
+        ok "${var_name}=${val} (derivado de ${parent_var})"
+    fi
+
+    if [ "${auto_create}" = "true" ]; then
+        if ! mkdir -p "${val}" 2>/dev/null; then
+            warn "Não foi possível criar ${val} — verifique permissões em $(dirname "${val}")"
+            return 1
+        fi
+        if [ -n "${default_mode}" ]; then
+            if ! chmod "${default_mode}" "${val}" 2>/dev/null; then
+                warn "Não foi possível aplicar chmod ${default_mode} em ${val}"
+                return 1
+            fi
+            info "Modo ${default_mode} aplicado em ${val}"
+        fi
+    fi
+
+    return 0
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# ensure_host_paths_derived ENV_FILE
+# Itera os elementos OBJETO de host_dir_vars (schema v2.0) e aplica
+# env_set_or_derive para cada um. Strings da forma legada são ignoradas —
+# elas são tratadas pela coleta interativa anterior + ensure_host_paths.
+#
+# Pré-requisito: PRODUCTS_FILE e SISCAN_PRODUCT já definidos.
+# ────────────────────────────────────────────────────────────────────────────
+ensure_host_paths_derived() {
+    local env_file="${1}"
+    local total=0 failed=0
+
+    # Sem manifesto, não há nada a derivar (compat retroativa).
+    if [ -z "${PRODUCTS_FILE:-}" ] || [ ! -f "${PRODUCTS_FILE:-}" ]; then
+        return 0
+    fi
+    command -v jq >/dev/null 2>&1 || return 0
+
+    while IFS=$'\t' read -r name derived_from derivation default_mode auto_create _description; do
+        [ -z "${name}" ] && continue
+        # Sentinela "-" emitido por product_get_host_dir_vars_derived para
+        # preservar campos vazios em IFS=tab. Reverter pra valor real.
+        [ "${default_mode}" = "-" ] && default_mode=""
+        total=$((total + 1))
+        if ! env_set_or_derive "${env_file}" "${name}" "${derived_from}" "${derivation}" "${default_mode}" "${auto_create}"; then
+            failed=$((failed + 1))
+        fi
+    done < <(product_get_host_dir_vars_derived)
+
+    [ "${total}" -eq 0 ] && return 0
+    return "${failed}"
 }
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -693,6 +826,17 @@ for var in "${HOST_PATH_VARS[@]}"; do
     fi
     printf "\n"
 done
+
+# ── HOST_* derivados (TSK00.05.01 #95) ──────────────────────────────────────
+# Variáveis declaradas como OBJETO em products.json.host_dir_vars[] — derivam
+# automaticamente do parent de uma variável-fonte (tipicamente HOST_LOG_DIR).
+# Hoje: HOST_SECRETS_DIR (mode 700) + HOST_BACKUPS_DIR para rpa/full.
+# Anteriormente: workflow CD do siscan-rpa fazia essa derivação inline
+# (linhas 311-352 do cd_imagem_certificada_selfhosted.yml) — movido pra cá
+# para que workflows passem a confiar no .env já configurado.
+printf "\n${WHITE}  Variáveis HOST_* derivadas automaticamente${NC}\n"
+printf "  ${GRAY}(declaradas em scripts/data/products.json — não requerem input)${NC}\n\n"
+ensure_host_paths_derived "${ENV_FILE}" || warn "Uma ou mais variáveis derivadas não puderam ser configuradas — revise ${ENV_FILE}"
 
 # ════════════════════════════════════════════════════════════════════════════
 step "FASE 6 — Criação dos diretórios HOST_*"

--- a/tests/unit/test_env_set_or_derive.bats
+++ b/tests/unit/test_env_set_or_derive.bats
@@ -1,0 +1,245 @@
+#!/usr/bin/env bats
+# Testes para env_set_or_derive + env_apply_derivation + ensure_host_paths_derived
+# (siscan-server-setup.sh — TSK00.05.01 #95)
+#
+# Cobre:
+#   - Derivação correta com `dirname + /<subdir>`
+#   - Preservação de valor pré-existente no .env (operador customizou)
+#   - Criação do diretório quando auto_create=true
+#   - Aplicação de default_mode (chmod) — secrets em 700
+#   - Comportamento gracioso quando parent_var está vazio (warn + return 1)
+#   - Compatibilidade com `dashboard` (sem variáveis derivadas — no-op)
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+setup() {
+    source "${BATS_TEST_DIRNAME}/../../siscan-server-setup.sh"
+    DATA_DIR="$(mktemp -d)"
+    ENV_FILE="${DATA_DIR}/.env"
+    PRODUCTS_FILE="${BATS_TEST_DIRNAME}/../../scripts/data/products.json"
+    export PRODUCTS_FILE
+}
+
+teardown() {
+    rm -rf "${DATA_DIR}"
+}
+
+# ── env_apply_derivation ────────────────────────────────────────────────────
+
+@test "env_apply_derivation: 'dirname + /secrets' extrai parent + concatena subdir" {
+    run env_apply_derivation "dirname + /secrets" "/opt/siscan/log"
+    assert_success
+    assert_output "/opt/siscan/secrets"
+}
+
+@test "env_apply_derivation: 'dirname + /backups' funciona com path aninhado" {
+    run env_apply_derivation "dirname + /backups" "/var/data/siscan/log"
+    assert_success
+    assert_output "/var/data/siscan/backups"
+}
+
+@test "env_apply_derivation: parent vazio retorna vazio (return 0, sem erro)" {
+    run env_apply_derivation "dirname + /secrets" ""
+    assert_success
+    assert_output ""
+}
+
+@test "env_apply_derivation: expressão desconhecida retorna 1" {
+    run env_apply_derivation "expressao_inventada" "/tmp/foo"
+    assert_failure
+}
+
+# ── env_set_or_derive — derivação ────────────────────────────────────────────
+
+@test "env_set_or_derive: deriva HOST_SECRETS_DIR de HOST_LOG_DIR (caso ausente)" {
+    cat > "${ENV_FILE}" <<EOF
+HOST_LOG_DIR=${DATA_DIR}/log
+EOF
+    run env_set_or_derive "${ENV_FILE}" HOST_SECRETS_DIR HOST_LOG_DIR "dirname + /secrets" "700" "true"
+    assert_success
+    run _read_env_value "${ENV_FILE}" HOST_SECRETS_DIR
+    assert_output "${DATA_DIR}/secrets"
+}
+
+@test "env_set_or_derive: cria diretório quando auto_create=true" {
+    cat > "${ENV_FILE}" <<EOF
+HOST_LOG_DIR=${DATA_DIR}/log
+EOF
+    env_set_or_derive "${ENV_FILE}" HOST_SECRETS_DIR HOST_LOG_DIR "dirname + /secrets" "700" "true"
+    [ -d "${DATA_DIR}/secrets" ]
+}
+
+@test "env_set_or_derive: aplica default_mode (700) em diretório criado" {
+    cat > "${ENV_FILE}" <<EOF
+HOST_LOG_DIR=${DATA_DIR}/log
+EOF
+    env_set_or_derive "${ENV_FILE}" HOST_SECRETS_DIR HOST_LOG_DIR "dirname + /secrets" "700" "true"
+    local perms
+    perms=$(stat -c '%a' "${DATA_DIR}/secrets")
+    [ "${perms}" = "700" ]
+}
+
+@test "env_set_or_derive: omite chmod quando default_mode vazio" {
+    cat > "${ENV_FILE}" <<EOF
+HOST_LOG_DIR=${DATA_DIR}/log
+EOF
+    env_set_or_derive "${ENV_FILE}" HOST_BACKUPS_DIR HOST_LOG_DIR "dirname + /backups" "" "true"
+    [ -d "${DATA_DIR}/backups" ]
+    # Sem chmod customizado → mode default (depende do umask, tipicamente 755)
+    local perms
+    perms=$(stat -c '%a' "${DATA_DIR}/backups")
+    [ "${perms}" != "700" ]
+}
+
+# ── env_set_or_derive — preservação ─────────────────────────────────────────
+
+@test "env_set_or_derive: preserva valor pré-existente no .env (operador customizou)" {
+    mkdir -p "${DATA_DIR}/custom/path"
+    cat > "${ENV_FILE}" <<EOF
+HOST_LOG_DIR=${DATA_DIR}/log
+HOST_SECRETS_DIR=${DATA_DIR}/custom/path
+EOF
+    env_set_or_derive "${ENV_FILE}" HOST_SECRETS_DIR HOST_LOG_DIR "dirname + /secrets" "700" "true"
+    run _read_env_value "${ENV_FILE}" HOST_SECRETS_DIR
+    assert_output "${DATA_DIR}/custom/path"
+}
+
+@test "env_set_or_derive: aplica chmod no caminho customizado quando preservado" {
+    mkdir -p "${DATA_DIR}/custom/path"
+    cat > "${ENV_FILE}" <<EOF
+HOST_LOG_DIR=${DATA_DIR}/log
+HOST_SECRETS_DIR=${DATA_DIR}/custom/path
+EOF
+    env_set_or_derive "${ENV_FILE}" HOST_SECRETS_DIR HOST_LOG_DIR "dirname + /secrets" "700" "true"
+    local perms
+    perms=$(stat -c '%a' "${DATA_DIR}/custom/path")
+    [ "${perms}" = "700" ]
+}
+
+@test "env_set_or_derive: é idempotente (rodar 2x não muda nada)" {
+    cat > "${ENV_FILE}" <<EOF
+HOST_LOG_DIR=${DATA_DIR}/log
+EOF
+    env_set_or_derive "${ENV_FILE}" HOST_SECRETS_DIR HOST_LOG_DIR "dirname + /secrets" "700" "true"
+    local first_md5
+    first_md5=$(md5sum "${ENV_FILE}" | awk '{print $1}')
+    env_set_or_derive "${ENV_FILE}" HOST_SECRETS_DIR HOST_LOG_DIR "dirname + /secrets" "700" "true"
+    local second_md5
+    second_md5=$(md5sum "${ENV_FILE}" | awk '{print $1}')
+    [ "${first_md5}" = "${second_md5}" ]
+}
+
+# ── env_set_or_derive — erros ────────────────────────────────────────────────
+
+@test "env_set_or_derive: warn + return 1 quando parent_var está vazio no .env" {
+    cat > "${ENV_FILE}" <<EOF
+# HOST_LOG_DIR não declarado
+SOMETHING=else
+EOF
+    run env_set_or_derive "${ENV_FILE}" HOST_SECRETS_DIR HOST_LOG_DIR "dirname + /secrets" "700" "true"
+    assert_failure
+}
+
+@test "env_set_or_derive: return 2 quando argumentos obrigatórios faltam" {
+    run env_set_or_derive "" "" "" ""
+    [ "${status}" -eq 2 ]
+}
+
+# ── ensure_host_paths_derived (integração com manifesto) ────────────────────
+
+@test "ensure_host_paths_derived (rpa): popula HOST_SECRETS_DIR + HOST_BACKUPS_DIR" {
+    cat > "${ENV_FILE}" <<EOF
+HOST_LOG_DIR=${DATA_DIR}/log
+EOF
+    SISCAN_PRODUCT=rpa
+    run ensure_host_paths_derived "${ENV_FILE}"
+    assert_success
+    grep -q "^HOST_SECRETS_DIR=${DATA_DIR}/secrets$" "${ENV_FILE}"
+    grep -q "^HOST_BACKUPS_DIR=${DATA_DIR}/backups$" "${ENV_FILE}"
+}
+
+@test "ensure_host_paths_derived (rpa): cria ambos os diretórios com modos corretos" {
+    cat > "${ENV_FILE}" <<EOF
+HOST_LOG_DIR=${DATA_DIR}/log
+EOF
+    SISCAN_PRODUCT=rpa
+    ensure_host_paths_derived "${ENV_FILE}"
+    [ -d "${DATA_DIR}/secrets" ]
+    [ -d "${DATA_DIR}/backups" ]
+    local secrets_perms
+    secrets_perms=$(stat -c '%a' "${DATA_DIR}/secrets")
+    [ "${secrets_perms}" = "700" ]
+}
+
+@test "ensure_host_paths_derived (dashboard): no-op (não tem objetos em host_dir_vars)" {
+    cat > "${ENV_FILE}" <<EOF
+HOST_LOG_DIR=${DATA_DIR}/log
+EOF
+    SISCAN_PRODUCT=dashboard
+    local before_md5
+    before_md5=$(md5sum "${ENV_FILE}" | awk '{print $1}')
+    run ensure_host_paths_derived "${ENV_FILE}"
+    assert_success
+    local after_md5
+    after_md5=$(md5sum "${ENV_FILE}" | awk '{print $1}')
+    [ "${before_md5}" = "${after_md5}" ]
+}
+
+@test "ensure_host_paths_derived (full): também popula HOST_SECRETS_DIR + HOST_BACKUPS_DIR" {
+    cat > "${ENV_FILE}" <<EOF
+HOST_LOG_DIR=${DATA_DIR}/log
+EOF
+    SISCAN_PRODUCT=full
+    run ensure_host_paths_derived "${ENV_FILE}"
+    assert_success
+    grep -q "^HOST_SECRETS_DIR=${DATA_DIR}/secrets$" "${ENV_FILE}"
+    grep -q "^HOST_BACKUPS_DIR=${DATA_DIR}/backups$" "${ENV_FILE}"
+}
+
+@test "ensure_host_paths_derived: no-op quando PRODUCTS_FILE não definido (backward compat)" {
+    cat > "${ENV_FILE}" <<EOF
+HOST_LOG_DIR=${DATA_DIR}/log
+EOF
+    PRODUCTS_FILE=""
+    SISCAN_PRODUCT=rpa
+    run ensure_host_paths_derived "${ENV_FILE}"
+    assert_success
+    ! grep -q "^HOST_SECRETS_DIR=" "${ENV_FILE}"
+}
+
+# ── product_get_host_dir_vars_derived (manifesto v2.0) ──────────────────────
+
+@test "product_get_host_dir_vars_derived (rpa): retorna 2 entradas TSV" {
+    SISCAN_PRODUCT=rpa
+    run product_get_host_dir_vars_derived
+    assert_success
+    local n
+    n=$(printf '%s\n' "${output}" | grep -c '^HOST_')
+    [ "${n}" -eq 2 ]
+}
+
+@test "product_get_host_dir_vars_derived (dashboard): vazio (sem objetos)" {
+    SISCAN_PRODUCT=dashboard
+    run product_get_host_dir_vars_derived
+    assert_success
+    assert_output ""
+}
+
+# ── product_get_array preserva semântica legada ─────────────────────────────
+
+@test "product_get_array host_dir_vars (rpa): emite SÓ strings (5 entradas, não 7)" {
+    SISCAN_PRODUCT=rpa
+    run product_get_array host_dir_vars
+    assert_success
+    local n
+    n=$(printf '%s\n' "${output}" | grep -c '^HOST_')
+    [ "${n}" -eq 5 ]
+}
+
+@test "product_get_array host_dir_vars (rpa): NÃO inclui HOST_SECRETS_DIR nem HOST_BACKUPS_DIR" {
+    SISCAN_PRODUCT=rpa
+    run product_get_array host_dir_vars
+    refute_output --partial "HOST_SECRETS_DIR"
+    refute_output --partial "HOST_BACKUPS_DIR"
+}


### PR DESCRIPTION
## Resumo

Move a derivação automática de `HOST_SECRETS_DIR` (mode 700) e `HOST_BACKUPS_DIR` — hoje implementada inline no workflow CD do `siscan-rpa` (linhas 311–352 de `cd_imagem_certificada_selfhosted.yml`) — para `siscan-server-setup.sh` Fase 5, declarado no manifesto `scripts/data/products.json` em **schema v2.0** (host_dir_vars passa a aceitar string E objeto). Pré-requisito de **T1** dos consumer repos `siscan-rpa#694` e `siscan-dashboard#525`, que vão remover esse step inline e confiar no `.env` produzido pelo setup.

## Por quê

- **Responsabilidade misplaced**: o workflow é o "deployer" — deveria assumir ambiente pronto, não configurá-lo
- Toda evolução do contrato (novos diretórios, novos modos) propaga via JSON sem mexer em N workflows
- Backward compatibility: schema v2.0 é aditivo, `product_get_array host_dir_vars` continua emitindo só strings (filtra objetos) — VMs com `.env` pré-existente não ganham falsos FAILs em check-env/check-permissions

## Mudanças

### 1. `scripts/data/products.json` v2.0 (aditivo)

`host_dir_vars[]` agora aceita STRING (forma legada — operador declara) OU OBJETO (forma nova — setup deriva). Campos do objeto: `name`, `derived_from`, `derivation` (suporta `"dirname + /<subdir>"`), `default_mode` (chmod), `auto_create` (mkdir -p), `description`.

`rpa` e `full` ganham `HOST_SECRETS_DIR` (mode 700) + `HOST_BACKUPS_DIR` como objetos. `dashboard` permanece só com strings (sem RSA keys).

### 2. `scripts/deploy_server/_common.sh`

- `product_get_array host_dir_vars` filtra para SÓ strings — preserva semântica histórica
- Novo `product_get_host_dir_vars_derived` — emite TSV dos elementos OBJETO (sentinela `-` para campos vazios, evita colapso de tabs adjacentes pelo bash `read`)

### 3. `siscan-server-setup.sh`

- Helper `env_apply_derivation` (extensível para futuras expressões além de `dirname + /<sub>`)
- Helper `env_set_or_derive ENV_FILE VAR PARENT_VAR DERIVATION [MODE] [AUTO_CREATE]` — idempotente: preserva valor pré-existente no `.env`, grava derivado se ausente, `mkdir -p` + `chmod` se aplicável
- Helper `ensure_host_paths_derived ENV_FILE` — itera objetos via `product_get_host_dir_vars_derived` e aplica `env_set_or_derive`
- Fase 5 chama `ensure_host_paths_derived` após coleta interativa das vars legacy
- Usa `ok/info/warn` (OUTPUT_MODE gates respeitados)

### 4. `docs/guides/siscan-server-doctor/products-manifest.md`

Schema v2.0 documentado com subseção dedicada para `host_dir_vars`: tabela de campos do objeto, semântica de preservação, backward compat de `product_get_array`.

### 5. `tests/unit/test_env_set_or_derive.bats`

22 testes cobrindo: `env_apply_derivation` (3 OK + 1 erro), `env_set_or_derive` (5 derivação + 2 preservação + 1 idempotência + 2 erro), `ensure_host_paths_derived` (rpa popula, dashboard no-op, full popula, no-op sem PRODUCTS_FILE), `product_get_host_dir_vars_derived` (rpa 2 entradas, dashboard vazio), `product_get_array` preserva semântica legada.

## Validação

- `bash -n` em `siscan-server-setup.sh` e `scripts/deploy_server/_common.sh`: OK
- `jq -e . scripts/data/products.json`: JSON válido (v2.0)
- `./tests/bats/bin/bats tests/unit/`: **218/218 verde** (196 originais + 22 novos)
- Smoke end-to-end em `/tmp`: derivação correta, `chmod 700` aplicado, preservação de valor customizado funciona, idempotência confirmada
- `bash siscan-server-setup.sh` (prompt interativo) renderiza normalmente — sem regressão visual

## Cross-references

- **Desbloqueia** [`siscan-rpa#694`](https://github.com/Prisma-Consultoria/siscan-rpa/issues/694) **T1** (remover step "Garantir HOST_SECRETS_DIR e HOST_BACKUPS_DIR" do workflow CD)
- **Desbloqueia** [`siscan-dashboard#525`](https://github.com/Prisma-Consultoria/siscan-dashboard/issues/525) **T1** (idem por simetria, embora dashboard não use RSA keys)
- Parte da feature [`#94`](https://github.com/Prisma-Consultoria/assistente-siscan-rpa/issues/94) (F00.05 — alinhar workflows externos)

## Test plan

- [x] Suite bats verde (218/218)
- [x] JSON v2.0 valida com `jq -e`
- [x] Smoke local end-to-end com manifesto rpa: cria `HOST_SECRETS_DIR` (700) + `HOST_BACKUPS_DIR` (755), grava no .env
- [x] Smoke idempotência: rodar 2x não muda nada
- [x] Smoke preservação: operador com `HOST_SECRETS_DIR` customizado mantém valor + ganha chmod
- [ ] Smoke em VM real (deferido para T1 dos consumer repos — depende da integração do workflow)

Closes #95
Refs #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)