### PR TITLE
feat: F00.06 — autoatualização agendada do assistente (cron + estado + pre-deploy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,8 @@ media/
 reports/
 
 *.txt
+
+# Estado de autoatualização do assistente (F00.06 — siscan-assistente-autoupdate.sh).
+# Por default vive fora do repo (${XDG_STATE_HOME:-$HOME/.local/state}/siscan-assistente/),
+# mas ignoramos o nome defensivamente caso SISCAN_UPDATE_STATE_FILE aponte para a árvore.
+update-state.json

--- a/.gitignore
+++ b/.gitignore
@@ -76,4 +76,7 @@ reports/
 # Estado de autoatualização do assistente (F00.06 — siscan-assistente-autoupdate.sh).
 # Por default vive fora do repo (${XDG_STATE_HOME:-$HOME/.local/state}/siscan-assistente/),
 # mas ignoramos o nome defensivamente caso SISCAN_UPDATE_STATE_FILE aponte para a árvore.
-update-state.json
+# Ancorado na raiz (/) — o único ponto in-tree possível é o $SCRIPT_DIR do clone;
+# evita mascarar um update-state.json homônimo de outro contexto em subdiretórios.
+/update-state.json
+/update-state.json.lock

--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -76,6 +76,7 @@ Este checklist se aplica a qualquer modo de deploy, independentemente do produto
 - [ ] Primeira coleta manual executada com sucesso.
 - [ ] `HOST_SECRETS_DIR` existe com `chmod 700` (chaves RSA): `stat -c '%a' $(grep ^HOST_SECRETS_DIR $COMPOSE_DIR/.env | cut -d= -f2)` → `700`.
 - [ ] Operador ciente do [fluxo de propriedade do compose file](DEPLOY_SERVER.md#fluxo-do-compose-file-de-produção) — não editar manualmente o compose na VM (sobrescrita silenciosa no próximo CD).
+- [ ] Autoatualização do assistente agendada: `bash siscan-assistente-autoupdate.sh schedule --daily --at 03:00` e conferida com `bash siscan-assistente-autoupdate.sh status` (ver [guia](guides/siscan-assistente-autoupdate.md)).
 
 ### Verificação de consistência (instalação existente)
 

--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -323,6 +323,29 @@ bash siscan-server-doctor.sh --pre-setup
 
 A última linha valida que o ambiente continua íntegro após o pull. Saída esperada: `7/7 specialists OK` (modo `--pre-setup` inclui `check-runner-tls` pre-flight + 6 prévios).
 
+### Autoatualização agendada (cron) — `siscan-assistente-autoupdate.sh`
+
+Para eliminar o `git pull` manual repetido, agende a atualização do clone via cron. O `siscan-assistente-autoupdate.sh` faz `git pull --ff-only origin main`, grava um **estado auditável** (commit, timestamp, resultado) fora do repo e expõe esse estado no `pre-deploy-diag.json` de todo deploy (chave `assistant_update`). Política de árvore suja fixada: se houver modificação em arquivos **rastreados**, o `run` grava `outcome: failed` e **não** toca no repo (nunca stasha silenciosamente).
+
+```bash
+cd $COMPOSE_DIR   # tipicamente /app/assistente-siscan-rpa
+
+# Agendar (diário às 03:00, ou a cada N dias; sem args entra em prompt interativo)
+bash siscan-assistente-autoupdate.sh schedule --daily --at 03:00
+bash siscan-assistente-autoupdate.sh schedule --every-days 3 --at 04:30
+
+# Conferir o estado da última atualização
+bash siscan-assistente-autoupdate.sh status
+
+# Rodar uma atualização agora (mesmo alvo do cron)
+bash siscan-assistente-autoupdate.sh run
+
+# Remover o agendamento (preserva o resto do crontab)
+bash siscan-assistente-autoupdate.sh unschedule
+```
+
+"A cada N dias" usa guarda de intervalo: o cron dispara diariamente e o `run` decide o ciclo comparando `last_success_utc` com `interval_days`. Detalhe dos subcomandos, esquema do estado e troubleshooting: [`guides/siscan-assistente-autoupdate.md`](guides/siscan-assistente-autoupdate.md).
+
 ### Cenários complexos (runner offline, auto-removed, primeira atualização ampla)
 
 Para recuperação cirúrgica do runner — auto-removido após 14 dias offline, regra dos 30 dias de auto-update, bootstrap em VM nova, serviço systemd ausente, entre outros — use `siscan-runner-recover.sh`. O script detecta automaticamente um entre **9 cenários auto-resolvíveis** (`OK`, `N/A`, `1`, `2`, `C`, `A`, `A2`, `B`, `WARN`) + 1 inconclusivo (`UNKNOWN`), compartilha a lógica de download/registro/instalação com `siscan-server-setup.sh` e valida ao final via `check-runner`. Detalhe de cada cenário, flags (`--token`, `--pat`, `--env-file`, `--product`), resolução do `ENV_FILE` e geração do PAT classic: [`guides/siscan-runner-recover.md`](guides/siscan-runner-recover.md).

--- a/docs/guides/siscan-assistente-autoupdate.md
+++ b/docs/guides/siscan-assistente-autoupdate.md
@@ -1,0 +1,200 @@
+---
+title: "siscan-assistente-autoupdate.sh — Autoatualização agendada do assistente"
+type: guide
+status: aceita
+confidencialidade: público
+owner: Time DevOps SISCAN
+updated: 2026-06-03
+versao: "1.0"
+related:
+  - docs/DEPLOY_SERVER.md
+  - docs/CHECKLISTS.md
+  - docs/guides/siscan-assistente.md
+  - docs/guides/siscan-runner-recover.md
+tags:
+  - assistente
+  - autoupdate
+  - cron
+  - git-pull
+  - deploy
+  - servidor
+tldr: |
+  Guia operacional de `siscan-assistente-autoupdate.sh` — automatiza o
+  `git pull --ff-only` do clone do assistente nas VMs de produção via cron
+  e expõe um estado auditável da última atualização (commit, timestamp,
+  resultado). Subcomandos: `run` (alvo do cron), `schedule`/`unschedule`
+  (instala/remove o bloco de cron gerenciado, com prompt interativo de
+  frequência) e `status` (resumo legível ou `--json` para máquina). O estado
+  vive fora do repo em `${XDG_STATE_HOME:-$HOME/.local/state}/siscan-assistente/`
+  e é fundido no `pre-deploy-diag.json` dos workflows CD (chave
+  `assistant_update`). "A cada N dias" via guarda de intervalo no `run`
+  (cron dispara diário). Feature F00.06 (issue #105).
+---
+
+# `siscan-assistente-autoupdate.sh` — Autoatualização agendada do assistente
+
+Automatiza a atualização do clone do assistente nas VMs de produção, eliminando o `git pull` manual repetido a cada operação, e **expõe o estado da última atualização** (commit, timestamp, resultado) de forma auditável — inclusive no diagnóstico `pre-deploy` dos workflows CD de `siscan-rpa` e `siscan-dashboard`.
+
+> **Issue de origem**: Feature F00.06 ([#105](https://github.com/Prisma-Consultoria/assistente-siscan-rpa/issues/105)).
+> **Modo coberto**: VMs de produção (modo SERVIDOR). O clone do assistente é a própria `${COMPOSE_DIR}` (tipicamente `/app/assistente-siscan-rpa`).
+> **Escopo**: atualiza **somente o clone do assistente** — não reinicia containers nem faz redeploy da imagem da aplicação (isso é responsabilidade dos workflows CD).
+
+## Motivação
+
+- Hoje cada operação exige rodar manualmente, na VM, `cd $COMPOSE_DIR && git pull origin main` + `git log -1 --oneline` para conferir a versão. É repetitivo, depende de pessoa e não deixa registro.
+- Não havia **fonte auditável** da "versão do ferramental em execução na VM" — diagnósticos e post-mortems precisavam inferir pelo comportamento.
+- O `pre-deploy` dos workflows CD já coleta diagnóstico; é o ponto natural para anexar *qual versão do assistente rodou este deploy*.
+
+## Subcomandos
+
+| Subcomando | Propósito |
+|---|---|
+| `run` | Alvo do cron. `git pull --ff-only origin main` no clone + grava o estado. |
+| `schedule` | Instala um bloco de cron gerenciado que dispara o `run` na frequência escolhida. |
+| `unschedule` | Remove apenas o bloco de cron gerenciado, preservando o resto do crontab. |
+| `status` | Imprime o estado da última atualização (resumo legível; `--json` para máquina). |
+
+```bash
+bash siscan-assistente-autoupdate.sh run [--quiet]
+bash siscan-assistente-autoupdate.sh schedule [--daily | --every-days N] --at HH:MM
+bash siscan-assistente-autoupdate.sh schedule          # prompt interativo
+bash siscan-assistente-autoupdate.sh unschedule
+bash siscan-assistente-autoupdate.sh status [--json]
+```
+
+## Pré-requisitos
+
+| Item | Detalhe |
+|---|---|
+| `git` | O clone deve ser um repositório git na branch `main`. |
+| `jq` | Serialização/leitura do arquivo de estado. |
+| `crontab` | Necessário só para `schedule`/`unschedule`. |
+| Daemon de cron | `cron`/`crond` ativo na VM — o `schedule` avisa (não bloqueia) se inativo. |
+
+O script sourceia `scripts/deploy_server/_common.sh` (helpers `ok/info/warn/fail`, `OUTPUT_MODE`, `require_commands`, `common_parse_arg`) e segue a convenção de exit codes `0` (sucesso) / `2` (falha).
+
+## `run` — atualização do clone
+
+O `run` é o alvo invocado pelo cron. Sequência:
+
+1. **Valida** que `$DIR_SISCAN_ASSISTENTE` é um repositório git na branch `main`. Caso contrário → `outcome: failed`, exit 2.
+2. **Guarda de árvore suja** (decisão fixada): se houver modificação em arquivos **rastreados** → grava `outcome: failed` + `warn` e **não faz pull**. O script nunca stasha nem mexe no repo silenciosamente — preserva qualquer edição local emergencial e deixa a reconciliação para o operador. Arquivos **não-rastreados** (untracked) **não** bloqueiam o `--ff-only`.
+3. **Guarda de intervalo**: se `interval_days > 1` e o último sucesso for recente, sai cedo com `outcome: skipped-interval`, exit 0 (ver ["A cada N dias"](#a-cada-n-dias)).
+4. **`git pull --ff-only origin main`** — nunca faz merge nem força. Histórico divergente → `outcome: failed`, exit 2.
+5. Captura `commit_before`/`commit_after`/`commits_pulled`/`commit_subject` e grava o estado **atomicamente** (`tmp` + `mv`).
+
+Desfechos possíveis (`outcome`):
+
+| `outcome` | Significado | Exit |
+|---|---|---|
+| `updated` | O clone avançou (`commit_before != commit_after`). | 0 |
+| `already-current` | Já na ponta de `origin/main`, nada a puxar. | 0 |
+| `skipped-interval` | Fora do ciclo de `interval_days` — não puxou. | 0 |
+| `failed` | Árvore suja, branch != main, ou `--ff-only` rejeitado. Repo intacto. | 2 |
+
+A flag `--quiet` torna o `run` compatível com cron (fail-only no stdout).
+
+## `schedule` / `unschedule` — agendamento via cron
+
+O `schedule` aceita a frequência por flags ou, quando ausentes, entra em **prompt interativo** (escolha diário × N-dias, depois `HH:MM` com validação 24h):
+
+```bash
+# Diariamente às 03:00
+bash siscan-assistente-autoupdate.sh schedule --daily --at 03:00
+
+# A cada 3 dias às 04:30
+bash siscan-assistente-autoupdate.sh schedule --every-days 3 --at 04:30
+
+# Interativo (pergunta frequência e horário)
+bash siscan-assistente-autoupdate.sh schedule
+```
+
+O agendamento instala um **bloco gerenciado por marcadores** no crontab do usuário:
+
+```cron
+# >>> siscan-assistente autoupdate (managed) >>>
+0 3 * * * DIR_SISCAN_ASSISTENTE="/app/assistente-siscan-rpa" SISCAN_UPDATE_STATE_FILE="..." /usr/bin/env bash "/app/assistente-siscan-rpa/siscan-assistente-autoupdate.sh" run --quiet
+# <<< siscan-assistente autoupdate <<<
+```
+
+- **Idempotente**: re-`schedule` substitui o bloco, não duplica.
+- A linha de cron exporta `DIR_SISCAN_ASSISTENTE` e `SISCAN_UPDATE_STATE_FILE` explicitamente, porque o ambiente do cron é mínimo (não herda as env vars de sessão).
+- `unschedule` remove **apenas** o bloco entre os marcadores; o resto do crontab é preservado (se o bloco era a única entrada, o crontab é removido).
+
+### "A cada N dias"
+
+Cron nativo não expressa "N dias" de forma confiável (`*/N` no dia-do-mês reinicia na virada do mês). Por isso:
+
+- O cron dispara **diariamente** no horário escolhido (campo de dia = `*`).
+- O `run` compara `last_success_utc` com `interval_days` (gravado no estado pelo `schedule`) e sai cedo com `skipped-interval` quando ainda não é o ciclo.
+
+Assim "a cada 3 dias" é exato e independente da virada de mês.
+
+## `status` — estado auditável
+
+```bash
+# Resumo legível (operador)
+bash siscan-assistente-autoupdate.sh status
+
+# JSON bruto (fonte do pre-deploy; {} quando o estado ainda não existe)
+bash siscan-assistente-autoupdate.sh status --json
+```
+
+O `status --json` é a **fonte única** consumida pelo step de `pre-deploy` dos workflows CD, que funde o estado no `pre-deploy-diag.json` sob a chave `assistant_update`:
+
+```yaml
+- name: Anexar estado de autoatualização do assistente
+  run: |
+    set -euo pipefail
+    cd "${COMPOSE_DIR}"
+    bash siscan-assistente-autoupdate.sh status --json > assistant-update.json || echo '{}' > assistant-update.json
+    jq -s '.[0] + {assistant_update: .[1]}' pre-deploy-diag.json assistant-update.json > merged.json
+    mv merged.json pre-deploy-diag.json
+```
+
+Esse step já está no template `docs/guides/workflows/templates/cd_imagem_certificada_selfhosted.template.yml`; a adoção nos consumers (`siscan-rpa`, `siscan-dashboard`) é propagada automaticamente pelo template.
+
+## Arquivo de estado
+
+O estado vive **fora do repo** (não suja o `git pull`):
+
+```
+${SISCAN_UPDATE_STATE_FILE:-${XDG_STATE_HOME:-$HOME/.local/state}/siscan-assistente/update-state.json}
+```
+
+Esquema (versão `1.0`):
+
+```json
+{
+  "schema": "1.0",
+  "outcome": "updated",
+  "branch": "main",
+  "commit_before": "54c180d",
+  "commit_after": "0ddd453",
+  "commit_subject": "...",
+  "commits_pulled": 3,
+  "last_attempt_utc": "2026-06-03T07:30:00Z",
+  "last_success_utc": "2026-06-03T07:30:00Z",
+  "schedule": { "interval_days": 1, "at": "03:00", "cron": "0 3 * * *" }
+}
+```
+
+Todos os timestamps são UTC ISO-8601 (`date -u +%Y-%m-%dT%H:%M:%SZ`). O arquivo é gravado atomicamente (`tmp` + `mv`). Apenas campos **sem PII** entram nele (SHAs, timestamps, `outcome`, `schedule`) — sem hostname/IP/nomes.
+
+## Troubleshooting
+
+| Sintoma | Causa provável | Resolução |
+|---|---|---|
+| `outcome: failed` + "Árvore de trabalho suja" | Arquivos **rastreados** modificados localmente. | Reconcilie manualmente: `git -C $DIR_SISCAN_ASSISTENTE status`, depois `git stash` / `git checkout -- <arquivo>` / `git commit`. O script nunca descarta alterações por conta própria. |
+| `outcome: failed` + "git pull --ff-only rejeitado" | Histórico divergente (commit local fora de `origin/main`) ou rede indisponível. | Verifique conectividade e `git -C $DIR_SISCAN_ASSISTENTE log --oneline origin/main..HEAD`. Resolva a divergência antes de reagendar. |
+| `outcome: failed` + "Branch '...' != main" | O clone não está em `main`. | `git -C $DIR_SISCAN_ASSISTENTE checkout main`. |
+| `outcome: skipped-interval` toda execução | `interval_days > 1` e ainda não passou o ciclo. | Esperado. Para forçar agora, rode `run` após zerar/ajustar o intervalo via novo `schedule --daily`. |
+| `schedule` avisa "Daemon de cron não parece ativo" | `cron`/`crond` parado na VM. | Inicie o daemon (`sudo systemctl enable --now cron`). O bloco já foi instalado; só não dispara sem o daemon. |
+| `status --json` retorna `{}` | Estado ainda não existe (nenhum `run` rodou). | Esperado em VM recém-provisionada — o `pre-deploy` trata `{}` como ausência. |
+
+## Veja também
+
+- [`siscan-assistente.md`](./siscan-assistente.md) — assistente interativo (modo HOST), que também oferece autoatualização do próprio assistente.
+- [`../DEPLOY_SERVER.md`](../DEPLOY_SERVER.md) — operação das VMs de produção e atualização do assistente.
+- [`../CHECKLISTS.md`](../CHECKLISTS.md) — checklist operacional.
+- [`siscan-runner-recover.md`](./siscan-runner-recover.md) — recuperação do self-hosted runner.

--- a/docs/guides/siscan-assistente-autoupdate.md
+++ b/docs/guides/siscan-assistente-autoupdate.md
@@ -146,10 +146,18 @@ O `status --json` é a **fonte única** consumida pelo step de `pre-deploy` dos 
 - name: Anexar estado de autoatualização do assistente
   run: |
     set -euo pipefail
+    : "${COMPOSE_DIR:?COMPOSE_DIR não definido — re-execute Fase 8 do siscan-server-setup.sh}"
     cd "${COMPOSE_DIR}"
     bash siscan-assistente-autoupdate.sh status --json > assistant-update.json || echo '{}' > assistant-update.json
-    jq -s '.[0] + {assistant_update: .[1]}' pre-deploy-diag.json assistant-update.json > merged.json
-    mv merged.json pre-deploy-diag.json
+    # Anexação não-bloqueante (diagnóstico): normaliza pre-deploy-diag não-objeto
+    # para {} e preserva o original em qualquer falha residual do jq.
+    if jq -s 'if (.[0]|type)=="object" then .[0] else {} end + {assistant_update: .[1]}' \
+          pre-deploy-diag.json assistant-update.json > merged.json; then
+      mv merged.json pre-deploy-diag.json
+    else
+      rm -f merged.json
+      echo "Aviso: merge do estado de autoatualização falhou — mantendo pre-deploy-diag.json original."
+    fi
 ```
 
 Esse step já está no template `docs/guides/workflows/templates/cd_imagem_certificada_selfhosted.template.yml`; a adoção nos consumers (`siscan-rpa`, `siscan-dashboard`) é propagada automaticamente pelo template.
@@ -186,6 +194,7 @@ Todos os timestamps são UTC ISO-8601 (`date -u +%Y-%m-%dT%H:%M:%SZ`). O arquivo
 | Sintoma | Causa provável | Resolução |
 |---|---|---|
 | `outcome: failed` + "Árvore de trabalho suja" | Arquivos **rastreados** modificados localmente. | Reconcilie manualmente: `git -C $DIR_SISCAN_ASSISTENTE status`, depois `git stash` / `git checkout -- <arquivo>` / `git commit`. O script nunca descarta alterações por conta própria. |
+| `outcome: failed` + "Árvore de trabalho suja" **logo após um deploy** | O job de `deploy` dos workflows CD copia `docker-compose`/`.env sample` **para dentro do `${COMPOSE_DIR}`** — o mesmo clone que o `run` atualiza. Se esses arquivos forem rastreados e o conteúdo copiado divergir do `HEAD`, a árvore fica suja e o `run` grava `failed` até a reconciliação. O `flock` protege apenas `run`×`run`, **não** `run`×`deploy`. | Verifique `git -C $COMPOSE_DIR status` — se os únicos arquivos sujos forem os copiados pelo CD (compose/env-sample), restaure-os (`git checkout -- <arquivo>`) ou comite-os; o `run` volta a puxar no próximo ciclo. Falha **segura** (não puxa durante a janela de deploy), mas pode mascarar-se de "autoupdate quebrado". |
 | `outcome: failed` + "git pull --ff-only rejeitado" | Histórico divergente (commit local fora de `origin/main`) ou rede indisponível. | Verifique conectividade e `git -C $DIR_SISCAN_ASSISTENTE log --oneline origin/main..HEAD`. Resolva a divergência antes de reagendar. |
 | `outcome: failed` + "Branch '...' != main" | O clone não está em `main`. | `git -C $DIR_SISCAN_ASSISTENTE checkout main`. |
 | `outcome: skipped-interval` toda execução | `interval_days > 1` e ainda não passou o ciclo. | Esperado. Para forçar agora, rode `run` após zerar/ajustar o intervalo via novo `schedule --daily`. |

--- a/docs/guides/siscan-assistente.md
+++ b/docs/guides/siscan-assistente.md
@@ -213,6 +213,8 @@ Atualiza o próprio script `siscan-assistente.sh` (ou `.ps1`) com **rollback aut
 
 Após sucesso, o assistente **encerra** — você precisa relançá-lo para usar a nova versão.
 
+> **Modo SERVIDOR (VMs de produção)**: a atualização do clone do assistente é **agendável via cron** com [`siscan-assistente-autoupdate.sh`](./siscan-assistente-autoupdate.md) (`git pull --ff-only` + estado auditável). Aquele utilitário cobre o cenário servidor; a Opção 7 aqui é para o modo HOST/PC local.
+
 ### Opção 8 — Sair
 
 Retorna ao shell sem desligar containers. A stack permanece como está (rodando se estava rodando).

--- a/docs/guides/workflows/templates/cd_imagem_certificada_selfhosted.template.yml
+++ b/docs/guides/workflows/templates/cd_imagem_certificada_selfhosted.template.yml
@@ -103,6 +103,18 @@ jobs:
             > pre-deploy-diag.json
           cat pre-deploy-diag.json
 
+      - name: Anexar estado de autoatualização do assistente
+        run: |
+          set -euo pipefail
+          cd "${COMPOSE_DIR}"
+          # Funde o estado de autoatualização (F00.06) no diagnóstico pre-deploy.
+          # Só campos sem PII (SHAs, timestamps, outcome, schedule) — o estado
+          # vive fora do repo na VM e nunca carrega hostname/IP. Fallback {}
+          # mantém o step não-bloqueante em VMs sem o estado ainda.
+          bash siscan-assistente-autoupdate.sh status --json > assistant-update.json || echo '{}' > assistant-update.json
+          jq -s '.[0] + {assistant_update: .[1]}' pre-deploy-diag.json assistant-update.json > merged.json
+          mv merged.json pre-deploy-diag.json
+
       - name: Coletar diagnóstico TLS do runner (pré-flight)
         run: |
           set -euo pipefail

--- a/docs/guides/workflows/templates/cd_imagem_certificada_selfhosted.template.yml
+++ b/docs/guides/workflows/templates/cd_imagem_certificada_selfhosted.template.yml
@@ -106,14 +106,24 @@ jobs:
       - name: Anexar estado de autoatualização do assistente
         run: |
           set -euo pipefail
+          : "${COMPOSE_DIR:?COMPOSE_DIR não definido — re-execute Fase 8 do siscan-server-setup.sh}"
           cd "${COMPOSE_DIR}"
           # Funde o estado de autoatualização (F00.06) no diagnóstico pre-deploy.
           # Só campos sem PII (SHAs, timestamps, outcome, schedule) — o estado
           # vive fora do repo na VM e nunca carrega hostname/IP. Fallback {}
           # mantém o step não-bloqueante em VMs sem o estado ainda.
           bash siscan-assistente-autoupdate.sh status --json > assistant-update.json || echo '{}' > assistant-update.json
-          jq -s '.[0] + {assistant_update: .[1]}' pre-deploy-diag.json assistant-update.json > merged.json
-          mv merged.json pre-deploy-diag.json
+          # Anexação não-bloqueante: é diagnóstico informativo. Se pre-deploy-diag
+          # não for um objeto (erro/array), normaliza para {} no merge para não
+          # derrubar o pre-deploy só por causa do campo informativo; em qualquer
+          # falha residual do jq, preserva o pre-deploy-diag.json original.
+          if jq -s 'if (.[0]|type)=="object" then .[0] else {} end + {assistant_update: .[1]}' \
+                pre-deploy-diag.json assistant-update.json > merged.json; then
+            mv merged.json pre-deploy-diag.json
+          else
+            rm -f merged.json
+            echo "Aviso: merge do estado de autoatualização falhou — mantendo pre-deploy-diag.json original."
+          fi
 
       - name: Coletar diagnóstico TLS do runner (pré-flight)
         run: |

--- a/siscan-assistente-autoupdate.sh
+++ b/siscan-assistente-autoupdate.sh
@@ -169,6 +169,14 @@ _state_write() {
     local tmp
     tmp="$(mktemp "${SISCAN_UPDATE_STATE_FILE}.XXXXXX")" || fail "Falha ao criar arquivo temporário do estado."
 
+    # Sanitiza os campos numéricos antes do --argjson: se o valor (lido de volta
+    # do estado, possivelmente editado à mão/gravação parcial) não for inteiro,
+    # normaliza para o default. Sem isso, um campo corrompido faria o jq -n
+    # abortar (--argjson exige JSON válido) e travaria o run em falha perpétua —
+    # o estado nunca se auto-curaria. Default coerente: 1 dia / 0 commits.
+    [[ "${commits_pulled:-0}" =~ ^[0-9]+$ ]] || commits_pulled=0
+    [[ "${interval_days:-1}" =~ ^[0-9]+$ ]] || interval_days=1
+
     # commits_pulled e interval_days são numéricos; demais são strings.
     # last_success_utc pode ser vazio (nunca houve sucesso) → null no JSON.
     jq -n \
@@ -215,9 +223,15 @@ cmd_run() {
         exec {lock_fd}>"$lock_file" || { _cmd_run_impl "$@"; return $?; }
         if ! flock -n "$lock_fd"; then
             warn "Outro 'run' está em andamento (lock $lock_file) — abortando para não colidir."
+            exec {lock_fd}>&-
             return 0
         fi
-        _cmd_run_impl "$@"
+        local rc=0
+        _cmd_run_impl "$@" || rc=$?
+        # Fecha o fd explicitamente (libera o flock) em vez de delegar ao término
+        # do processo — torna a intenção clara e libera o lock no caminho de sucesso.
+        exec {lock_fd}>&-
+        return "$rc"
     else
         _cmd_run_impl "$@"
     fi
@@ -233,6 +247,11 @@ _cmd_run_impl() {
     # Estado pré-existente: preservamos schedule + last_success na regravação.
     local prev_interval prev_at prev_cron prev_success
     prev_interval="$(_state_read_schedule interval_days)"; prev_interval="${prev_interval:-1}"
+    # Normaliza intervalo não-numérico lido do estado: evita que a guarda de
+    # intervalo (comparação aritmética `-gt` adiante) emita "integer expression
+    # expected" no stderr — em cron --quiet isso vira e-mail espúrio e a guarda
+    # seria silenciosamente ignorada (decisão de ciclo incorreta).
+    [[ "$prev_interval" =~ ^[0-9]+$ ]] || prev_interval=1
     prev_at="$(_state_read_schedule at)"
     prev_cron="$(_state_read_schedule cron)"
     prev_success="$(_state_read_field last_success_utc)"
@@ -356,7 +375,14 @@ cmd_schedule() {
                 fi
                 freq="every-days"; interval_days="$2"; shift 2 ;;
             --every-days=*)  freq="every-days"; interval_days="${1#*=}"; shift ;;
-            --at)            [ $# -ge 2 ] || fail "--at requer HH:MM."; at="$2"; shift 2 ;;
+            --at)
+                # Rejeita $2 ausente, vazio ou iniciado por '-' (outra flag),
+                # alinhado com --every-days; sem isso `--at --daily` aceitaria
+                # at="--daily" e só falharia depois com "Horário inválido".
+                if [ $# -lt 2 ] || [ -z "${2:-}" ] || [[ "$2" == -* ]]; then
+                    fail "--at requer HH:MM."
+                fi
+                at="$2"; shift 2 ;;
             --at=*)          at="${1#*=}"; shift ;;
             *)               fail "argumento desconhecido para schedule: $1" ;;
         esac

--- a/siscan-assistente-autoupdate.sh
+++ b/siscan-assistente-autoupdate.sh
@@ -203,7 +203,28 @@ _state_write() {
 # ────────────────────────────────────────────────────────────────────────────
 # Subcomando: run
 # ────────────────────────────────────────────────────────────────────────────
+
+# cmd_run — wrapper que serializa a execução com um lock no arquivo de estado,
+# evitando que um run manual colida com o disparo do cron (gravações
+# concorrentes do estado → outcome 'failed' espúrio). Degrada gracioso: se
+# 'flock' não existir no host, segue sem lock (comportamento original).
 cmd_run() {
+    if command -v flock >/dev/null 2>&1; then
+        mkdir -p "$(dirname "$SISCAN_UPDATE_STATE_FILE")"
+        local lock_file="${SISCAN_UPDATE_STATE_FILE}.lock"
+        exec {lock_fd}>"$lock_file" || { _cmd_run_impl "$@"; return $?; }
+        if ! flock -n "$lock_fd"; then
+            warn "Outro 'run' está em andamento (lock $lock_file) — abortando para não colidir."
+            return 0
+        fi
+        _cmd_run_impl "$@"
+    else
+        _cmd_run_impl "$@"
+    fi
+}
+
+# _cmd_run_impl — corpo do run (pull --ff-only + gravação de estado).
+_cmd_run_impl() {
     require_commands git jq
 
     local repo="$DIR_SISCAN_ASSISTENTE"
@@ -242,15 +263,21 @@ cmd_run() {
     # Guarda de intervalo: se interval_days > 1 e o último sucesso é recente,
     # sai cedo com skipped-interval (cron dispara diário; o run decide o ciclo).
     if [ "${prev_interval:-1}" -gt 1 ] && [ -n "$prev_success" ]; then
-        local last_epoch now_epoch elapsed_days
+        local last_epoch now_epoch elapsed_secs interval_secs
         last_epoch="$(date -u -d "$prev_success" +%s 2>/dev/null || echo 0)"
         now_epoch="$(date -u +%s)"
         if [ "$last_epoch" -gt 0 ]; then
-            elapsed_days=$(( (now_epoch - last_epoch) / 86400 ))
-            if [ "$elapsed_days" -lt "$prev_interval" ]; then
+            # Compara em segundos com folga de 1h: o cron dispara diário e o
+            # horário real tem jitter de segundos/minutos; truncar para dias
+            # faria 47h59m virar "1 dia" e pular indevidamente o ciclo de 2 dias.
+            # A folga (interval*86400 - 3600) garante que ~N dias menos uma hora
+            # já conte como ciclo cumprido.
+            elapsed_secs=$(( now_epoch - last_epoch ))
+            interval_secs=$(( prev_interval * 86400 - 3600 ))
+            if [ "$elapsed_secs" -lt "$interval_secs" ]; then
                 _state_write "skipped-interval" "$branch" "$commit_before" "$commit_before" "" 0 "$now" "$prev_success" \
                     "$prev_interval" "$prev_at" "$prev_cron"
-                info "Fora do ciclo: ${elapsed_days}d desde o último sucesso < interval_days=${prev_interval}. Estado=skipped-interval."
+                info "Fora do ciclo: $(( elapsed_secs / 3600 ))h desde o último sucesso < interval_days=${prev_interval} (folga 1h). Estado=skipped-interval."
                 return 0
             fi
         fi
@@ -262,8 +289,9 @@ cmd_run() {
     if [ "$pull_rc" -ne 0 ]; then
         _state_write "failed" "$branch" "$commit_before" "$commit_before" "" 0 "$now" "$prev_success" \
             "$prev_interval" "$prev_at" "$prev_cron"
-        warn "git pull --ff-only falhou (divergência ou rede): $(printf '%s' "$pull_out" | tail -1)"
-        fail "git pull --ff-only rejeitado em $repo. Histórico divergente ou rede indisponível — reconcilie manualmente."
+        local pull_last; pull_last="$(printf '%s' "$pull_out" | tail -1)"
+        warn "git pull --ff-only falhou (divergência ou rede): $pull_last"
+        fail "git pull --ff-only rejeitado em $repo: ${pull_last:-erro desconhecido}. Reconcilie manualmente."
     fi
 
     local commit_after commits_pulled commit_subject outcome
@@ -379,10 +407,14 @@ cmd_schedule() {
     self="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
     local cron_line="$cron DIR_SISCAN_ASSISTENTE=\"$DIR_SISCAN_ASSISTENTE\" SISCAN_UPDATE_STATE_FILE=\"$SISCAN_UPDATE_STATE_FILE\" /usr/bin/env bash \"$self\" run --quiet"
 
+    # PATH explícito dentro do bloco: o cron roda com ambiente mínimo e algumas
+    # VMs instalam git/jq em /usr/local/bin (fora do PATH default do cron).
+    local cron_path="PATH=/usr/local/bin:/usr/bin:/bin"
+
     # Instala bloco gerenciado idempotente: remove o bloco antigo, anexa o novo.
     local base new_crontab
     base="$(_crontab_without_block)"
-    new_crontab="$(printf '%s\n%s\n%s\n%s\n' "$base" "$CRON_BEGIN" "$cron_line" "$CRON_END")"
+    new_crontab="$(printf '%s\n%s\n%s\n%s\n%s\n' "$base" "$CRON_BEGIN" "$cron_path" "$cron_line" "$CRON_END")"
     # Normaliza linhas em branco no topo (quando não havia crontab).
     new_crontab="$(printf '%s\n' "$new_crontab" | sed '/^$/N;/^\n$/D')"
     printf '%s\n' "$new_crontab" | crontab - || fail "Falha ao instalar o crontab."
@@ -446,9 +478,13 @@ cmd_status() {
     require_commands jq
 
     if [ "$OUTPUT_MODE" = "json" ]; then
-        # Fonte única para o pre-deploy. Ausente → {} (não falha).
+        # Fonte única para o pre-deploy (fundida em artifact de CI). Ausente →
+        # {} (não falha). Omitimos commit_subject: é texto livre de `git log -1
+        # %s` e o diagnóstico pre-deploy é publicado como artifact — não deve
+        # carregar conteúdo de mensagem de commit. O campo permanece no arquivo
+        # de estado e no `status` human (debug local).
         if [ -f "$SISCAN_UPDATE_STATE_FILE" ]; then
-            jq '.' "$SISCAN_UPDATE_STATE_FILE" 2>/dev/null || echo '{}'
+            jq 'del(.commit_subject)' "$SISCAN_UPDATE_STATE_FILE" 2>/dev/null || echo '{}'
         else
             echo '{}'
         fi
@@ -524,10 +560,10 @@ main() {
     done
 
     case "$subcmd" in
-        run)        cmd_run "${rest[@]:-}" ;;
-        schedule)   cmd_schedule "${rest[@]:-}" ;;
-        unschedule) cmd_unschedule "${rest[@]:-}" ;;
-        status)     cmd_status "${rest[@]:-}" ;;
+        run)        cmd_run "${rest[@]}" ;;
+        schedule)   cmd_schedule "${rest[@]}" ;;
+        unschedule) cmd_unschedule "${rest[@]}" ;;
+        status)     cmd_status "${rest[@]}" ;;
         *) printf "subcomando desconhecido: %s\n" "$subcmd" >&2; usage >&2; exit 2 ;;
     esac
 }

--- a/siscan-assistente-autoupdate.sh
+++ b/siscan-assistente-autoupdate.sh
@@ -1,0 +1,535 @@
+#!/usr/bin/env bash
+# -------------------------------------------
+# SISCAN Assistente Autoupdate — Autoatualização agendada do clone do assistente
+# -------------------------------------------
+# Arquivo: siscan-assistente-autoupdate.sh
+# Propósito: automatizar o `git pull --ff-only` do clone do assistente nas VMs
+#            de produção (eliminando o pull manual repetido) e expor o estado
+#            da última atualização (commit, timestamp, resultado) de forma
+#            auditável — inclusive no diagnóstico pre-deploy dos workflows CD.
+#
+# Feature F00.06 (issue #105). Sub-tasks: #106 (run), #107 (schedule/
+# unschedule), #108 (status + template), #109 (docs).
+#
+# Interface por subcomandos:
+#   run         Alvo do cron: git pull --ff-only origin main + grava estado.
+#   schedule    Instala bloco de cron gerenciado que dispara `run`.
+#   unschedule  Remove o bloco de cron gerenciado.
+#   status      Imprime o estado da última atualização (--json para máquina).
+#
+# Uso:
+#   bash ./siscan-assistente-autoupdate.sh run [--quiet]
+#   bash ./siscan-assistente-autoupdate.sh schedule [--daily | --every-days N] --at HH:MM
+#   bash ./siscan-assistente-autoupdate.sh schedule          # prompt interativo
+#   bash ./siscan-assistente-autoupdate.sh unschedule
+#   bash ./siscan-assistente-autoupdate.sh status [--json]
+#   bash ./siscan-assistente-autoupdate.sh --help
+#
+# Variáveis de ambiente opcionais:
+#   DIR_SISCAN_ASSISTENTE     Raiz do clone do assistente (default: dir do script).
+#   SISCAN_UPDATE_STATE_FILE  Caminho do arquivo de estado (default:
+#                             ${XDG_STATE_HOME:-$HOME/.local/state}/siscan-assistente/update-state.json).
+#
+# Decisão de design — árvore suja: se houver modificação em arquivos
+# RASTREADOS, o `run` grava outcome=failed + warn e NÃO faz pull. O script
+# nunca stasha nem mexe no repo silenciosamente — preserva qualquer alteração
+# local (ex.: edição manual emergencial) e deixa a reconciliação para o
+# operador. Arquivos não-rastreados (untracked) NÃO bloqueiam o ff-only.
+#
+# "A cada N dias": cron nativo não expressa N dias de forma confiável
+# (*/N no dia-do-mês reinicia na virada). Solução: o cron dispara DIARIAMENTE
+# no horário escolhido e o `run` compara last_success_utc com interval_days,
+# saindo cedo (outcome=skipped-interval) quando não é o ciclo.
+#
+# Exit code:
+#   0  sucesso (updated / already-current / skipped-interval / status / schedule)
+#   2  qualquer falha — uso inválido, pré-condição não atendida, árvore suja,
+#      pull rejeitado. O helper fail() de _common.sh sempre sai com 2.
+#
+# Referência: docs/guides/siscan-assistente-autoupdate.md
+# -------------------------------------------
+
+# shellcheck disable=SC2059
+# SC2059: o padrão do projeto usa variáveis de cor ($CYAN/$NC/...) dentro do
+# format string do printf (ver siscan-runner-recover.sh). Mantido por
+# consistência — as variáveis são literais ANSI controladas, não input externo.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPECIALISTS_DIR="$SCRIPT_DIR/scripts/deploy_server"
+
+# Source da biblioteca comum (cores, helpers ok/info/warn/fail, OUTPUT_MODE,
+# common_parse_arg, require_commands).
+# shellcheck disable=SC2034  # usado por require_commands()/fail() em _common.sh
+SPECIALIST_NAME="autoupdate"
+# shellcheck source=scripts/deploy_server/_common.sh
+source "$SPECIALISTS_DIR/_common.sh"
+
+# Default human; subcomandos ajustam (status --json muda via common_parse_arg).
+OUTPUT_MODE="human"
+_setup_colors
+
+# ────────────────────────────────────────────────────────────────────────────
+# Configuração
+# ────────────────────────────────────────────────────────────────────────────
+# Raiz do clone a atualizar. Honra DIR_SISCAN_ASSISTENTE (persistida pelo
+# siscan-assistente.sh), com fallback para o diretório do próprio script —
+# que, em produção, é a raiz do clone (${COMPOSE_DIR}).
+DIR_SISCAN_ASSISTENTE="${DIR_SISCAN_ASSISTENTE:-$SCRIPT_DIR}"
+
+# Arquivo de estado fora do repo (não suja o git pull). Caminho canônico
+# persistível via SISCAN_UPDATE_STATE_FILE (mesmo padrão do DIR_SISCAN_ASSISTENTE).
+_default_state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/siscan-assistente"
+SISCAN_UPDATE_STATE_FILE="${SISCAN_UPDATE_STATE_FILE:-${_default_state_dir}/update-state.json}"
+
+SCHEMA_VERSION="1.0"
+
+# Marcadores do bloco de cron gerenciado (não alterar — usados para detecção
+# idempotente e remoção cirúrgica).
+CRON_BEGIN="# >>> siscan-assistente autoupdate (managed) >>>"
+CRON_END="# <<< siscan-assistente autoupdate <<<"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Ajuda
+# ────────────────────────────────────────────────────────────────────────────
+usage() {
+    cat <<EOF
+Uso: bash $(basename "$0") <subcomando> [opções]
+
+Subcomandos:
+  run                       Atualiza o clone (git pull --ff-only origin main) e
+                            grava o estado. Alvo do cron.
+  schedule                  Instala bloco de cron gerenciado que dispara o run.
+  unschedule                Remove o bloco de cron gerenciado.
+  status                    Imprime o estado da última atualização.
+
+Opções de 'run':
+  --quiet                   Fail-only no stdout (contrato de cron).
+
+Opções de 'schedule':
+  --daily                   Dispara todos os dias.
+  --every-days N            Dispara a cada N dias (guarda de intervalo no run).
+  --at HH:MM                Horário do disparo (24h). Sem --daily/--every-days/--at
+                            o script entra em prompt interativo.
+
+Opções de 'status':
+  --json                    Imprime o estado bruto em JSON ({} se ausente).
+
+Comuns:
+  -h, --help                Esta ajuda.
+
+Variáveis de ambiente:
+  DIR_SISCAN_ASSISTENTE     Raiz do clone (default: diretório do script).
+  SISCAN_UPDATE_STATE_FILE  Arquivo de estado (default:
+                            \${XDG_STATE_HOME:-\$HOME/.local/state}/siscan-assistente/update-state.json).
+
+Exit code: 0 = sucesso · 2 = falha (uso / pré-cond / árvore suja / pull rejeitado)
+
+Referência: docs/guides/siscan-assistente-autoupdate.md
+EOF
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Helpers de estado
+# ────────────────────────────────────────────────────────────────────────────
+
+# _now_utc — timestamp UTC ISO-8601 (formato do schema do estado).
+_now_utc() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# _state_read_field FIELD — lê um campo escalar do estado via jq (vazio se
+# ausente/arquivo inexistente). Mantém o read tolerante a estado ausente.
+_state_read_field() {
+    local field="$1"
+    [ -f "$SISCAN_UPDATE_STATE_FILE" ] || return 0
+    jq -r --arg f "$field" '.[$f] // empty' "$SISCAN_UPDATE_STATE_FILE" 2>/dev/null
+}
+
+# _state_read_schedule FIELD — lê schedule.FIELD do estado (vazio se ausente).
+_state_read_schedule() {
+    local field="$1"
+    [ -f "$SISCAN_UPDATE_STATE_FILE" ] || return 0
+    jq -r --arg f "$field" '.schedule[$f] // empty' "$SISCAN_UPDATE_STATE_FILE" 2>/dev/null
+}
+
+# _state_write — escreve o arquivo de estado atomicamente (tmp + mv).
+# Recebe via variáveis os campos correntes; preserva schedule e last_success_utc
+# quando o caller não os sobrescreve (lidos ANTES no run/schedule).
+#
+# Args (posicionais):
+#   $1 outcome      $2 branch          $3 commit_before  $4 commit_after
+#   $5 commit_subject  $6 commits_pulled  $7 last_attempt_utc  $8 last_success_utc
+#   $9 interval_days   $10 schedule_at    $11 schedule_cron
+_state_write() {
+    local outcome="$1" branch="$2" commit_before="$3" commit_after="$4"
+    local commit_subject="$5" commits_pulled="$6" last_attempt="$7" last_success="$8"
+    local interval_days="$9" sched_at="${10}" sched_cron="${11}"
+
+    mkdir -p "$(dirname "$SISCAN_UPDATE_STATE_FILE")"
+    local tmp
+    tmp="$(mktemp "${SISCAN_UPDATE_STATE_FILE}.XXXXXX")" || fail "Falha ao criar arquivo temporário do estado."
+
+    # commits_pulled e interval_days são numéricos; demais são strings.
+    # last_success_utc pode ser vazio (nunca houve sucesso) → null no JSON.
+    jq -n \
+        --arg schema "$SCHEMA_VERSION" \
+        --arg outcome "$outcome" \
+        --arg branch "$branch" \
+        --arg cb "$commit_before" \
+        --arg ca "$commit_after" \
+        --arg cs "$commit_subject" \
+        --argjson cp "${commits_pulled:-0}" \
+        --arg la "$last_attempt" \
+        --arg ls "$last_success" \
+        --argjson idays "${interval_days:-1}" \
+        --arg sat "$sched_at" \
+        --arg scron "$sched_cron" \
+        '{
+          schema: $schema,
+          outcome: $outcome,
+          branch: $branch,
+          commit_before: $cb,
+          commit_after: $ca,
+          commit_subject: $cs,
+          commits_pulled: $cp,
+          last_attempt_utc: (if $la == "" then null else $la end),
+          last_success_utc: (if $ls == "" then null else $ls end),
+          schedule: { interval_days: $idays, at: $sat, cron: $scron }
+        }' > "$tmp" || { command rm -f "$tmp"; fail "Falha ao serializar o estado (jq)."; }
+
+    mv -f "$tmp" "$SISCAN_UPDATE_STATE_FILE" || { command rm -f "$tmp"; fail "Falha ao gravar o estado."; }
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Subcomando: run
+# ────────────────────────────────────────────────────────────────────────────
+cmd_run() {
+    require_commands git jq
+
+    local repo="$DIR_SISCAN_ASSISTENTE"
+    local now; now="$(_now_utc)"
+
+    # Estado pré-existente: preservamos schedule + last_success na regravação.
+    local prev_interval prev_at prev_cron prev_success
+    prev_interval="$(_state_read_schedule interval_days)"; prev_interval="${prev_interval:-1}"
+    prev_at="$(_state_read_schedule at)"
+    prev_cron="$(_state_read_schedule cron)"
+    prev_success="$(_state_read_field last_success_utc)"
+
+    [ -d "$repo/.git" ] || fail "Não é um repositório git: $repo (defina DIR_SISCAN_ASSISTENTE)."
+
+    local branch
+    branch="$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    if [ "$branch" != "main" ]; then
+        _state_write "failed" "$branch" "" "" "" 0 "$now" "$prev_success" \
+            "$prev_interval" "$prev_at" "$prev_cron"
+        warn "Branch atual é '$branch', não 'main' — não atualizo. Estado=failed."
+        fail "Branch '$branch' != main. Faça checkout de main antes de agendar a autoatualização."
+    fi
+
+    local commit_before
+    commit_before="$(git -C "$repo" rev-parse --short HEAD 2>/dev/null)"
+
+    # Guarda de árvore suja: SÓ arquivos rastreados (untracked não bloqueia).
+    # Política fixada: nunca stasha/mexe no repo silenciosamente.
+    if ! git -C "$repo" diff --quiet || ! git -C "$repo" diff --cached --quiet; then
+        _state_write "failed" "$branch" "$commit_before" "$commit_before" "" 0 "$now" "$prev_success" \
+            "$prev_interval" "$prev_at" "$prev_cron"
+        warn "Árvore de trabalho suja (arquivos rastreados modificados) — não faço pull. Estado=failed."
+        fail "Há modificações locais em arquivos rastreados de $repo. Reconcilie manualmente (git stash/commit/checkout) antes da autoatualização."
+    fi
+
+    # Guarda de intervalo: se interval_days > 1 e o último sucesso é recente,
+    # sai cedo com skipped-interval (cron dispara diário; o run decide o ciclo).
+    if [ "${prev_interval:-1}" -gt 1 ] && [ -n "$prev_success" ]; then
+        local last_epoch now_epoch elapsed_days
+        last_epoch="$(date -u -d "$prev_success" +%s 2>/dev/null || echo 0)"
+        now_epoch="$(date -u +%s)"
+        if [ "$last_epoch" -gt 0 ]; then
+            elapsed_days=$(( (now_epoch - last_epoch) / 86400 ))
+            if [ "$elapsed_days" -lt "$prev_interval" ]; then
+                _state_write "skipped-interval" "$branch" "$commit_before" "$commit_before" "" 0 "$now" "$prev_success" \
+                    "$prev_interval" "$prev_at" "$prev_cron"
+                info "Fora do ciclo: ${elapsed_days}d desde o último sucesso < interval_days=${prev_interval}. Estado=skipped-interval."
+                return 0
+            fi
+        fi
+    fi
+
+    # Pull fast-forward only — nunca faz merge nem força.
+    local pull_out pull_rc
+    pull_out="$(git -C "$repo" pull --ff-only origin "$branch" 2>&1)"; pull_rc=$?
+    if [ "$pull_rc" -ne 0 ]; then
+        _state_write "failed" "$branch" "$commit_before" "$commit_before" "" 0 "$now" "$prev_success" \
+            "$prev_interval" "$prev_at" "$prev_cron"
+        warn "git pull --ff-only falhou (divergência ou rede): $(printf '%s' "$pull_out" | tail -1)"
+        fail "git pull --ff-only rejeitado em $repo. Histórico divergente ou rede indisponível — reconcilie manualmente."
+    fi
+
+    local commit_after commits_pulled commit_subject outcome
+    commit_after="$(git -C "$repo" rev-parse --short HEAD 2>/dev/null)"
+    commit_subject="$(git -C "$repo" log -1 --pretty=%s 2>/dev/null)"
+    commits_pulled="$(git -C "$repo" rev-list --count "${commit_before}..${commit_after}" 2>/dev/null || echo 0)"
+
+    if [ "$commit_before" = "$commit_after" ]; then
+        outcome="already-current"
+        info "Já na ponta de origin/$branch ($commit_after). Nada a atualizar."
+    else
+        outcome="updated"
+        ok "Atualizado: $commit_before → $commit_after (${commits_pulled} commit(s)). HEAD: $commit_subject"
+    fi
+
+    _state_write "$outcome" "$branch" "$commit_before" "$commit_after" "$commit_subject" \
+        "$commits_pulled" "$now" "$now" "$prev_interval" "$prev_at" "$prev_cron"
+    return 0
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Subcomando: schedule / unschedule
+# ────────────────────────────────────────────────────────────────────────────
+
+# _validate_hhmm HH:MM — valida horário 24h. Retorna 0 se válido.
+_validate_hhmm() {
+    [[ "$1" =~ ^([01][0-9]|2[0-3]):[0-5][0-9]$ ]]
+}
+
+# _crontab_without_block — imprime o crontab atual SEM o bloco gerenciado.
+# Trata "sem crontab ainda" (crontab -l falha) como vazio.
+_crontab_without_block() {
+    local current
+    current="$(crontab -l 2>/dev/null || true)"
+    [ -n "$current" ] || return 0
+    printf '%s\n' "$current" | awk -v b="$CRON_BEGIN" -v e="$CRON_END" '
+        $0 == b { skip=1; next }
+        $0 == e { skip=0; next }
+        skip != 1 { print }
+    '
+}
+
+cmd_schedule() {
+    require_commands crontab git jq
+
+    # Aviso (não-bloqueante) se o daemon de cron não parece ativo.
+    if command -v systemctl >/dev/null 2>&1; then
+        if ! systemctl is-active --quiet cron 2>/dev/null \
+           && ! systemctl is-active --quiet crond 2>/dev/null; then
+            warn "Daemon de cron não parece ativo (cron/crond). O agendamento só dispara com o daemon rodando."
+        fi
+    fi
+
+    local freq="" interval_days=1 at=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --daily)         freq="daily"; interval_days=1; shift ;;
+            --every-days)
+                if [ $# -lt 2 ] || [ -z "${2:-}" ]; then
+                    fail "--every-days requer um número de dias."
+                fi
+                freq="every-days"; interval_days="$2"; shift 2 ;;
+            --every-days=*)  freq="every-days"; interval_days="${1#*=}"; shift ;;
+            --at)            [ $# -ge 2 ] || fail "--at requer HH:MM."; at="$2"; shift 2 ;;
+            --at=*)          at="${1#*=}"; shift ;;
+            *)               fail "argumento desconhecido para schedule: $1" ;;
+        esac
+    done
+
+    # Prompt interativo quando a frequência não foi passada (espelha o estilo
+    # interativo dos demais scripts do assistente).
+    if [ -z "$freq" ]; then
+        printf "${CYAN}Frequência da autoatualização:${NC}\n"
+        printf "  ${WHITE}1)${NC} Diária\n"
+        printf "  ${WHITE}2)${NC} A cada N dias\n"
+        local choice=""
+        # shellcheck disable=SC2162
+        read -rp "Escolha [1-2]: " choice
+        case "$choice" in
+            1) freq="daily"; interval_days=1 ;;
+            2)
+                freq="every-days"
+                # shellcheck disable=SC2162
+                read -rp "A cada quantos dias? (>=2): " interval_days
+                ;;
+            *) fail "Escolha inválida: $choice" ;;
+        esac
+    fi
+
+    # Validação do intervalo.
+    if [ "$freq" = "every-days" ]; then
+        [[ "$interval_days" =~ ^[0-9]+$ ]] || fail "interval_days deve ser inteiro: $interval_days"
+        [ "$interval_days" -ge 2 ] || fail "--every-days exige N >= 2 (use --daily para 1)."
+    fi
+
+    # Prompt do horário quando ausente.
+    if [ -z "$at" ]; then
+        # shellcheck disable=SC2162
+        read -rp "Horário do disparo (HH:MM, 24h): " at
+    fi
+    _validate_hhmm "$at" || fail "Horário inválido: '$at' (use HH:MM, 24h, ex.: 03:00)."
+
+    local hh="${at%%:*}" mm="${at##*:}"
+    # Remove zero à esquerda para o cron (campo numérico, sem 08 octal).
+    hh="$((10#$hh))"; mm="$((10#$mm))"
+    local cron="$mm $hh * * *"
+
+    # Linha de cron: invoca o run com --quiet (contrato de cron: fail-only).
+    # Caminho absoluto do script + DIR_SISCAN_ASSISTENTE explícito (cron tem
+    # ambiente mínimo, sem garantia das env vars de sessão).
+    local self
+    self="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
+    local cron_line="$cron DIR_SISCAN_ASSISTENTE=\"$DIR_SISCAN_ASSISTENTE\" SISCAN_UPDATE_STATE_FILE=\"$SISCAN_UPDATE_STATE_FILE\" /usr/bin/env bash \"$self\" run --quiet"
+
+    # Instala bloco gerenciado idempotente: remove o bloco antigo, anexa o novo.
+    local base new_crontab
+    base="$(_crontab_without_block)"
+    new_crontab="$(printf '%s\n%s\n%s\n%s\n' "$base" "$CRON_BEGIN" "$cron_line" "$CRON_END")"
+    # Normaliza linhas em branco no topo (quando não havia crontab).
+    new_crontab="$(printf '%s\n' "$new_crontab" | sed '/^$/N;/^\n$/D')"
+    printf '%s\n' "$new_crontab" | crontab - || fail "Falha ao instalar o crontab."
+
+    # Persiste a frequência no estado (a guarda de intervalo vive no run).
+    # Preserva os campos de execução existentes (não reseta last_success etc.).
+    local now; now="$(_now_utc)"
+    local p_outcome p_cb p_ca p_cs p_cp p_la p_ls
+    p_outcome="$(_state_read_field outcome)"
+    p_cb="$(_state_read_field commit_before)"
+    p_ca="$(_state_read_field commit_after)"
+    p_cs="$(_state_read_field commit_subject)"
+    p_cp="$(_state_read_field commits_pulled)"; p_cp="${p_cp:-0}"
+    p_la="$(_state_read_field last_attempt_utc)"
+    p_ls="$(_state_read_field last_success_utc)"
+    [ -n "$p_outcome" ] || p_outcome="scheduled"
+
+    _state_write "$p_outcome" "main" "$p_cb" "$p_ca" "$p_cs" "$p_cp" \
+        "${p_la:-$now}" "$p_ls" "$interval_days" "$at" "$cron"
+
+    if [ "$freq" = "daily" ]; then
+        ok "Agendado: diariamente às $at (cron: '$cron')."
+    else
+        ok "Agendado: a cada $interval_days dias às $at (cron diário '$cron' + guarda de intervalo no run)."
+    fi
+    info "Estado: $SISCAN_UPDATE_STATE_FILE"
+    info "Inspecione com: crontab -l"
+    return 0
+}
+
+cmd_unschedule() {
+    require_commands crontab
+
+    local current
+    current="$(crontab -l 2>/dev/null || true)"
+    if [ -z "$current" ]; then
+        info "Nenhum crontab instalado — nada a remover."
+        return 0
+    fi
+    if ! printf '%s\n' "$current" | grep -qF "$CRON_BEGIN"; then
+        info "Bloco gerenciado ausente no crontab — nada a remover."
+        return 0
+    fi
+
+    local base
+    base="$(_crontab_without_block)"
+    if [ -z "$base" ]; then
+        # Crontab ficaria vazio → remove o crontab por completo.
+        crontab -r 2>/dev/null || true
+    else
+        printf '%s\n' "$base" | crontab - || fail "Falha ao reescrever o crontab sem o bloco gerenciado."
+    fi
+    ok "Bloco de autoatualização removido do crontab (resto preservado)."
+    return 0
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Subcomando: status
+# ────────────────────────────────────────────────────────────────────────────
+cmd_status() {
+    require_commands jq
+
+    if [ "$OUTPUT_MODE" = "json" ]; then
+        # Fonte única para o pre-deploy. Ausente → {} (não falha).
+        if [ -f "$SISCAN_UPDATE_STATE_FILE" ]; then
+            jq '.' "$SISCAN_UPDATE_STATE_FILE" 2>/dev/null || echo '{}'
+        else
+            echo '{}'
+        fi
+        return 0
+    fi
+
+    # Human: resumo legível.
+    if [ ! -f "$SISCAN_UPDATE_STATE_FILE" ]; then
+        info "Sem estado de autoatualização registrado ($SISCAN_UPDATE_STATE_FILE)."
+        info "Rode 'bash $(basename "${BASH_SOURCE[0]}") run' ou agende com 'schedule'."
+        return 0
+    fi
+
+    local outcome branch ca cs cp la ls idays sat scron
+    outcome="$(_state_read_field outcome)"
+    branch="$(_state_read_field branch)"
+    ca="$(_state_read_field commit_after)"
+    cs="$(_state_read_field commit_subject)"
+    cp="$(_state_read_field commits_pulled)"
+    la="$(_state_read_field last_attempt_utc)"
+    ls="$(_state_read_field last_success_utc)"
+    idays="$(_state_read_schedule interval_days)"
+    sat="$(_state_read_schedule at)"
+    scron="$(_state_read_schedule cron)"
+
+    printf "${WHITE}Estado da autoatualização do assistente${NC}\n"
+    info "Arquivo:        $SISCAN_UPDATE_STATE_FILE"
+    info "Resultado:      ${outcome:-—}"
+    info "Branch:         ${branch:-—}"
+    info "HEAD atual:     ${ca:-—}${cs:+  ($cs)}"
+    info "Commits puxados:${cp:+ $cp}"
+    info "Última tentativa: ${la:-—}"
+    info "Último sucesso:   ${ls:-nunca}"
+    if [ -n "$scron" ]; then
+        if [ "${idays:-1}" -gt 1 ] 2>/dev/null; then
+            info "Agendamento:    a cada ${idays} dias às ${sat} (cron '$scron')"
+        else
+            info "Agendamento:    diário às ${sat} (cron '$scron')"
+        fi
+    else
+        info "Agendamento:    não agendado"
+    fi
+    return 0
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Dispatch de subcomando
+# ────────────────────────────────────────────────────────────────────────────
+main() {
+    # --help/-h em qualquer posição antes do subcomando.
+    if [ $# -eq 0 ]; then
+        usage >&2
+        exit 2
+    fi
+
+    local subcmd="$1"; shift || true
+    case "$subcmd" in
+        -h|--help) usage; exit 0 ;;
+    esac
+
+    # Parse de flags comuns (--quiet/--json) + coleta do resto para o subcomando.
+    local rest=()
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help) usage; exit 0 ;;
+        esac
+        if common_parse_arg "$@"; then
+            # shellcheck disable=SC2154  # shift_count é setado por common_parse_arg
+            shift "$shift_count"
+        else
+            rest+=("$1"); shift
+        fi
+    done
+
+    case "$subcmd" in
+        run)        cmd_run "${rest[@]:-}" ;;
+        schedule)   cmd_schedule "${rest[@]:-}" ;;
+        unschedule) cmd_unschedule "${rest[@]:-}" ;;
+        status)     cmd_status "${rest[@]:-}" ;;
+        *) printf "subcomando desconhecido: %s\n" "$subcmd" >&2; usage >&2; exit 2 ;;
+    esac
+}
+
+main "$@"

--- a/tests/unit/test_autoupdate_run.bats
+++ b/tests/unit/test_autoupdate_run.bats
@@ -108,6 +108,60 @@ EOF
     assert_equal "$(state_field '.schedule.interval_days')" "3"
 }
 
+@test "run: interval_days=2 com ~47.5h decorridas NÃO pula (folga de 1h)" {
+    # Guarda de intervalo compara em segundos com folga de 1h
+    # (interval*86400 - 3600). Para interval=2 o limiar é 169200s (47h).
+    # Com 47.5h (171000s) decorridos, o ciclo está cumprido → o run DEVE puxar,
+    # não gravar skipped-interval. Antes (truncando p/ dias), 47h virava "1 dia"
+    # < 2 → SKIP indevido. Este teste guarda contra essa derrapagem.
+    git -C "${CLONE}" reset -q --hard HEAD~1   # clone atrás → há o que puxar
+    local before; before="$(git -C "${CLONE}" rev-parse --short HEAD)"
+
+    mkdir -p "$(dirname "${STATE_FILE}")"
+    # last_success = agora - 47.5h (171000s).
+    local past; past="$(date -u -d "@$(( $(date -u +%s) - 171000 ))" +%Y-%m-%dT%H:%M:%SZ)"
+    cat > "${STATE_FILE}" <<EOF
+{"schema":"1.0","outcome":"updated","branch":"main","commit_before":"x","commit_after":"x","commit_subject":"s","commits_pulled":0,"last_attempt_utc":"${past}","last_success_utc":"${past}","schedule":{"interval_days":2,"at":"03:00","cron":"0 3 * * *"}}
+EOF
+
+    run bash "${SCRIPT}" run
+    assert_success
+    # NÃO pulou: ciclo cumprido → puxou e avançou.
+    assert_equal "$(state_field '.outcome')" "updated"
+    [ "${before}" != "$(git -C "${CLONE}" rev-parse --short HEAD)" ]
+}
+
+@test "run: interval_days=2 com ~24h decorridas pula (skipped-interval)" {
+    # Contraprova: 24h (86400s) << limiar 169200s → ainda dentro do ciclo de 2d.
+    git -C "${CLONE}" reset -q --hard HEAD~1
+    local head_before; head_before="$(git -C "${CLONE}" rev-parse HEAD)"
+
+    mkdir -p "$(dirname "${STATE_FILE}")"
+    local past; past="$(date -u -d "@$(( $(date -u +%s) - 86400 ))" +%Y-%m-%dT%H:%M:%SZ)"
+    cat > "${STATE_FILE}" <<EOF
+{"schema":"1.0","outcome":"updated","branch":"main","commit_before":"x","commit_after":"x","commit_subject":"s","commits_pulled":0,"last_attempt_utc":"${past}","last_success_utc":"${past}","schedule":{"interval_days":2,"at":"03:00","cron":"0 3 * * *"}}
+EOF
+
+    run bash "${SCRIPT}" run
+    assert_success
+    assert_equal "$(state_field '.outcome')" "skipped-interval"
+    assert_equal "$(git -C "${CLONE}" rev-parse HEAD)" "${head_before}"
+}
+
+# ── lock (M2) ────────────────────────────────────────────────────────────────
+
+@test "run: degrada gracioso sem flock no PATH (segue sem lock)" {
+    # PATH restrito a um bin sem 'flock', mas com git/jq via symlink p/ os reais.
+    local fakebin="${TEST_DIR}/nolock_bin"
+    mkdir -p "${fakebin}"
+    for c in bash git jq date mktemp mkdir mv rm sed awk cat dirname basename env tail printf grep; do
+        local p; p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "${fakebin}/$c"
+    done
+    run env PATH="${fakebin}" bash "${SCRIPT}" run
+    assert_success
+    assert_equal "$(state_field '.outcome')" "already-current"
+}
+
 # ── failed-dirty ────────────────────────────────────────────────────────────
 
 @test "run: árvore suja (rastreado modificado) grava failed, repo intacto, exit 2" {

--- a/tests/unit/test_autoupdate_run.bats
+++ b/tests/unit/test_autoupdate_run.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# Testes para o subcomando `run` de siscan-assistente-autoupdate.sh (TSK00.06.01).
+#
+# Cobre os 4 desfechos do `run`:
+#   updated          — repo atrasado avança via git pull --ff-only.
+#   already-current  — repo já na ponta de origin/main.
+#   skipped-interval — interval_days>1 e último sucesso recente (guarda).
+#   failed-dirty     — árvore suja (arquivos rastreados) → repo intacto, exit 2.
+#
+# Estratégia: monta um "origin" git local + um clone, copia o script + a
+# dependência _common.sh para dentro do clone (igual ao layout de produção,
+# onde o script roda da raiz do clone). Estado e DIR são injetados por env var,
+# sem tocar no $HOME real.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+SCRIPT_NAME="siscan-assistente-autoupdate.sh"
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    TEST_DIR="$(mktemp -d)"
+    ORIGIN="${TEST_DIR}/origin"
+    CLONE="${TEST_DIR}/clone"
+    STATE_FILE="${TEST_DIR}/state/update-state.json"
+    export SISCAN_UPDATE_STATE_FILE="${STATE_FILE}"
+    export DIR_SISCAN_ASSISTENTE="${CLONE}"
+
+    # Origin com 2 commits.
+    git init -q -b main "${ORIGIN}"
+    git -C "${ORIGIN}" config user.email "t@example.test"
+    git -C "${ORIGIN}" config user.name "tester"
+    echo "v1" > "${ORIGIN}/file.txt"
+    git -C "${ORIGIN}" add . && git -C "${ORIGIN}" commit -qm "c1"
+    git -C "${ORIGIN}" commit -q --allow-empty -m "c2"
+
+    git clone -q "${ORIGIN}" "${CLONE}"
+    git -C "${CLONE}" config user.email "t@example.test"
+    git -C "${CLONE}" config user.name "tester"
+
+    # Replica o layout de produção: script na raiz + _common.sh disponível.
+    cp "${REPO_ROOT}/${SCRIPT_NAME}" "${CLONE}/"
+    mkdir -p "${CLONE}/scripts/deploy_server"
+    cp "${REPO_ROOT}/scripts/deploy_server/_common.sh" "${CLONE}/scripts/deploy_server/"
+
+    SCRIPT="${CLONE}/${SCRIPT_NAME}"
+}
+
+teardown() {
+    rm -rf "${TEST_DIR}"
+    unset SISCAN_UPDATE_STATE_FILE DIR_SISCAN_ASSISTENTE
+}
+
+# Helper: lê um campo escalar do estado gravado.
+state_field() { jq -r "$1" "${STATE_FILE}"; }
+
+# ── updated ─────────────────────────────────────────────────────────────────
+
+@test "run: repo atrasado avança e grava outcome=updated com SHAs corretos" {
+    git -C "${CLONE}" reset -q --hard HEAD~1   # clone fica 1 commit atrás
+    local before after
+    before="$(git -C "${CLONE}" rev-parse --short HEAD)"
+
+    run bash "${SCRIPT}" run
+    assert_success
+
+    after="$(git -C "${CLONE}" rev-parse --short HEAD)"
+    [ "${before}" != "${after}" ]
+    assert_equal "$(state_field '.outcome')" "updated"
+    assert_equal "$(state_field '.commit_before')" "${before}"
+    assert_equal "$(state_field '.commit_after')" "${after}"
+    assert_equal "$(state_field '.commits_pulled')" "1"
+    assert_equal "$(state_field '.branch')" "main"
+    # last_success_utc preenchido em sucesso.
+    [ "$(state_field '.last_success_utc')" != "null" ]
+}
+
+# ── already-current ─────────────────────────────────────────────────────────
+
+@test "run: repo na ponta grava outcome=already-current sem erro" {
+    run bash "${SCRIPT}" run
+    assert_success
+    assert_equal "$(state_field '.outcome')" "already-current"
+    assert_equal "$(state_field '.commits_pulled')" "0"
+    assert_equal "$(state_field '.commit_before')" "$(state_field '.commit_after')"
+}
+
+# ── skipped-interval ────────────────────────────────────────────────────────
+
+@test "run: dentro do intervalo (interval_days>1, sucesso recente) grava skipped-interval e sai 0" {
+    git -C "${CLONE}" reset -q --hard HEAD~1   # clone atrás (haveria o que puxar)
+    local head_before
+    head_before="$(git -C "${CLONE}" rev-parse HEAD)"
+
+    # Estado pré-existente: interval 3, sucesso agora.
+    mkdir -p "$(dirname "${STATE_FILE}")"
+    local now; now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    cat > "${STATE_FILE}" <<EOF
+{"schema":"1.0","outcome":"updated","branch":"main","commit_before":"x","commit_after":"x","commit_subject":"s","commits_pulled":0,"last_attempt_utc":"${now}","last_success_utc":"${now}","schedule":{"interval_days":3,"at":"03:00","cron":"0 3 * * *"}}
+EOF
+
+    run bash "${SCRIPT}" run
+    assert_success
+    assert_equal "$(state_field '.outcome')" "skipped-interval"
+    # Repo NÃO foi atualizado (guarda saiu antes do pull).
+    assert_equal "$(git -C "${CLONE}" rev-parse HEAD)" "${head_before}"
+    # interval_days preservado.
+    assert_equal "$(state_field '.schedule.interval_days')" "3"
+}
+
+# ── failed-dirty ────────────────────────────────────────────────────────────
+
+@test "run: árvore suja (rastreado modificado) grava failed, repo intacto, exit 2" {
+    git -C "${CLONE}" reset -q --hard HEAD~1
+    echo "edição local" >> "${CLONE}/file.txt"   # arquivo RASTREADO modificado
+    local head_before
+    head_before="$(git -C "${CLONE}" rev-parse HEAD)"
+
+    run bash "${SCRIPT}" run
+    assert_failure 2
+    assert_equal "$(state_field '.outcome')" "failed"
+    # Repo não tocado: HEAD igual e modificação local preservada.
+    assert_equal "$(git -C "${CLONE}" rev-parse HEAD)" "${head_before}"
+    grep -q "edição local" "${CLONE}/file.txt"
+}
+
+@test "run: arquivo NÃO-rastreado não bloqueia o pull" {
+    git -C "${CLONE}" reset -q --hard HEAD~1
+    touch "${CLONE}/arquivo_novo_nao_rastreado.txt"
+
+    run bash "${SCRIPT}" run
+    assert_success
+    assert_equal "$(state_field '.outcome')" "updated"
+}
+
+# ── precondições ────────────────────────────────────────────────────────────
+
+@test "run: branch != main grava failed e sai 2" {
+    git -C "${CLONE}" checkout -q -b outra
+    run bash "${SCRIPT}" run
+    assert_failure 2
+    assert_equal "$(state_field '.outcome')" "failed"
+    assert_equal "$(state_field '.branch')" "outra"
+}
+
+@test "status --json sem estado retorna {} e sai 0" {
+    rm -f "${STATE_FILE}"
+    run bash "${SCRIPT}" status --json
+    assert_success
+    assert_output "{}"
+}
+
+@test "status --json após run reflete o estado gravado" {
+    bash "${SCRIPT}" run >/dev/null
+    run bash "${SCRIPT}" status --json
+    assert_success
+    assert_output --partial '"outcome"'
+    assert_output --partial '"schema": "1.0"'
+}

--- a/tests/unit/test_autoupdate_run.bats
+++ b/tests/unit/test_autoupdate_run.bats
@@ -197,6 +197,39 @@ EOF
     assert_equal "$(state_field '.branch')" "outra"
 }
 
+# ── estado corrompido (F1/F2) ─────────────────────────────────────────────────
+
+@test "run: interval_days não-numérico no estado não trava o run (auto-cura, exit 0)" {
+    # Estado adulterado/parcial: interval_days="abc". Antes, o --argjson do
+    # _state_write abortava (jq: invalid JSON) → fail → exit 2 em TODA execução,
+    # travando o run permanentemente. Agora o campo é sanitizado para o default.
+    mkdir -p "$(dirname "${STATE_FILE}")"
+    cat > "${STATE_FILE}" <<'EOF'
+{"schema":"1.0","outcome":"updated","branch":"main","commit_before":"x","commit_after":"x","commit_subject":"s","commits_pulled":0,"last_attempt_utc":null,"last_success_utc":null,"schedule":{"interval_days":"abc","at":"03:00","cron":"0 3 * * *"}}
+EOF
+    run bash "${SCRIPT}" run
+    assert_success
+    # Estado regravado com o campo normalizado para inteiro (default 1).
+    assert_equal "$(state_field '.schedule.interval_days')" "1"
+    # Sem poluição de stderr ("integer expression expected").
+    refute_output --partial "integer expression expected"
+}
+
+@test "run: commits_pulled não-numérico no estado não trava o run (auto-cura)" {
+    # F1: commits_pulled também é passado via --argjson. Valor não-numérico
+    # lido de volta (gravação parcial/edição) deve normalizar para 0, não abortar.
+    git -C "${CLONE}" reset -q --hard HEAD~1   # há o que puxar
+    mkdir -p "$(dirname "${STATE_FILE}")"
+    cat > "${STATE_FILE}" <<'EOF'
+{"schema":"1.0","outcome":"updated","branch":"main","commit_before":"x","commit_after":"x","commit_subject":"s","commits_pulled":"oops","last_attempt_utc":null,"last_success_utc":null,"schedule":{"interval_days":1,"at":"03:00","cron":"0 3 * * *"}}
+EOF
+    run bash "${SCRIPT}" run
+    assert_success
+    assert_equal "$(state_field '.outcome')" "updated"
+    # commits_pulled regravado como número válido (1 commit puxado).
+    assert_equal "$(state_field '.commits_pulled')" "1"
+}
+
 @test "status --json sem estado retorna {} e sai 0" {
     rm -f "${STATE_FILE}"
     run bash "${SCRIPT}" status --json

--- a/tests/unit/test_autoupdate_schedule.bats
+++ b/tests/unit/test_autoupdate_schedule.bats
@@ -1,0 +1,172 @@
+#!/usr/bin/env bats
+# Testes para os subcomandos `schedule`/`unschedule` de
+# siscan-assistente-autoupdate.sh (TSK00.06.02).
+#
+# Cobre:
+#   - parse de frequência → cron (--daily, --every-days N) + --at HH:MM.
+#   - idempotência (re-schedule substitui o bloco, não duplica).
+#   - unschedule cirúrgico (preserva o resto do crontab).
+#   - validação de horário (HH:MM 24h).
+#
+# crontab é substituído por um stub em PATH que persiste num arquivo
+# (FAKE_CRONTAB_FILE) — não toca no crontab real do usuário/CI. systemctl
+# também é stubado para silenciar o aviso de daemon de cron.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+SCRIPT_NAME="siscan-assistente-autoupdate.sh"
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    TEST_DIR="$(mktemp -d)"
+    CLONE="${TEST_DIR}/clone"
+    STATE_FILE="${TEST_DIR}/state/update-state.json"
+    FAKE_CRONTAB_FILE="${TEST_DIR}/fake_crontab"
+    export SISCAN_UPDATE_STATE_FILE="${STATE_FILE}"
+    export DIR_SISCAN_ASSISTENTE="${CLONE}"
+    export FAKE_CRONTAB_FILE
+
+    # Clone git mínimo (schedule chama require_commands git jq mas não pulla).
+    git init -q -b main "${CLONE}"
+    git -C "${CLONE}" config user.email "t@example.test"
+    git -C "${CLONE}" config user.name "tester"
+    git -C "${CLONE}" commit -q --allow-empty -m "c1"
+
+    cp "${REPO_ROOT}/${SCRIPT_NAME}" "${CLONE}/"
+    mkdir -p "${CLONE}/scripts/deploy_server"
+    cp "${REPO_ROOT}/scripts/deploy_server/_common.sh" "${CLONE}/scripts/deploy_server/"
+    SCRIPT="${CLONE}/${SCRIPT_NAME}"
+
+    # Stub bin dir em PATH: crontab + systemctl.
+    STUB_BIN="${TEST_DIR}/bin"
+    mkdir -p "${STUB_BIN}"
+    cat > "${STUB_BIN}/crontab" <<'EOF'
+#!/usr/bin/env bash
+STORE="${FAKE_CRONTAB_FILE}"
+case "$1" in
+  -l) [ -f "$STORE" ] && cat "$STORE" || { echo "no crontab for user" >&2; exit 1; } ;;
+  -r) rm -f "$STORE" ;;
+  -)  cat > "$STORE" ;;
+  *)  echo "crontab stub: unsupported $*" >&2; exit 2 ;;
+esac
+EOF
+    chmod +x "${STUB_BIN}/crontab"
+    # systemctl stub: reporta cron ativo (silencia o warn).
+    cat > "${STUB_BIN}/systemctl" <<'EOF'
+#!/usr/bin/env bash
+[ "$1" = "is-active" ] && exit 0
+exit 0
+EOF
+    chmod +x "${STUB_BIN}/systemctl"
+    export PATH="${STUB_BIN}:${PATH}"
+}
+
+teardown() {
+    rm -rf "${TEST_DIR}"
+    unset SISCAN_UPDATE_STATE_FILE DIR_SISCAN_ASSISTENTE FAKE_CRONTAB_FILE
+}
+
+# ── parse de frequência → cron ──────────────────────────────────────────────
+
+@test "schedule --daily --at 03:00 gera cron '0 3 * * *' e interval_days=1" {
+    run bash "${SCRIPT}" schedule --daily --at 03:00
+    assert_success
+    grep -q '^0 3 \* \* \*' "${FAKE_CRONTAB_FILE}"
+    assert_equal "$(jq -r '.schedule.cron' "${STATE_FILE}")" "0 3 * * *"
+    assert_equal "$(jq -r '.schedule.interval_days' "${STATE_FILE}")" "1"
+    assert_equal "$(jq -r '.schedule.at' "${STATE_FILE}")" "03:00"
+}
+
+@test "schedule --every-days 3 --at 04:30 grava cron '30 4 * * *' + interval_days=3" {
+    run bash "${SCRIPT}" schedule --every-days 3 --at 04:30
+    assert_success
+    assert_equal "$(jq -r '.schedule.cron' "${STATE_FILE}")" "30 4 * * *"
+    assert_equal "$(jq -r '.schedule.interval_days' "${STATE_FILE}")" "3"
+    grep -q '^30 4 \* \* \*' "${FAKE_CRONTAB_FILE}"
+}
+
+@test "schedule remove zero à esquerda do horário (08:05 -> '5 8 * * *')" {
+    run bash "${SCRIPT}" schedule --daily --at 08:05
+    assert_success
+    assert_equal "$(jq -r '.schedule.cron' "${STATE_FILE}")" "5 8 * * *"
+}
+
+# ── bloco gerenciado por marcadores ─────────────────────────────────────────
+
+@test "schedule instala bloco com marcadores begin/end" {
+    bash "${SCRIPT}" schedule --daily --at 01:00
+    grep -qF '# >>> siscan-assistente autoupdate (managed) >>>' "${FAKE_CRONTAB_FILE}"
+    grep -qF '# <<< siscan-assistente autoupdate <<<' "${FAKE_CRONTAB_FILE}"
+    grep -q 'run --quiet' "${FAKE_CRONTAB_FILE}"
+}
+
+# ── idempotência ────────────────────────────────────────────────────────────
+
+@test "re-schedule substitui o bloco sem duplicar" {
+    bash "${SCRIPT}" schedule --daily --at 01:00
+    bash "${SCRIPT}" schedule --daily --at 02:00
+    # Apenas UM bloco gerenciado.
+    assert_equal "$(grep -cF '# >>> siscan-assistente autoupdate (managed) >>>' "${FAKE_CRONTAB_FILE}")" "1"
+    assert_equal "$(grep -cF '# <<< siscan-assistente autoupdate <<<' "${FAKE_CRONTAB_FILE}")" "1"
+    # E reflete o NOVO horário.
+    grep -q '^0 2 \* \* \*' "${FAKE_CRONTAB_FILE}"
+    ! grep -q '^0 1 \* \* \*' "${FAKE_CRONTAB_FILE}"
+}
+
+# ── unschedule cirúrgico ────────────────────────────────────────────────────
+
+@test "unschedule remove só o bloco gerenciado, preservando o resto do crontab" {
+    # Entrada de usuário pré-existente.
+    cat > "${FAKE_CRONTAB_FILE}" <<'EOF'
+# job do usuário
+0 0 * * * echo ola
+EOF
+    bash "${SCRIPT}" schedule --daily --at 05:00
+    grep -qF 'managed' "${FAKE_CRONTAB_FILE}"
+
+    run bash "${SCRIPT}" unschedule
+    assert_success
+    # Bloco gerenciado sumiu, job do usuário permanece.
+    ! grep -qF 'managed' "${FAKE_CRONTAB_FILE}"
+    grep -qF '0 0 * * * echo ola' "${FAKE_CRONTAB_FILE}"
+    grep -qF '# job do usuário' "${FAKE_CRONTAB_FILE}"
+}
+
+@test "unschedule sem crontab é no-op e sai 0" {
+    rm -f "${FAKE_CRONTAB_FILE}"
+    run bash "${SCRIPT}" unschedule
+    assert_success
+}
+
+@test "unschedule sem bloco gerenciado preserva crontab e sai 0" {
+    cat > "${FAKE_CRONTAB_FILE}" <<'EOF'
+0 0 * * * echo ola
+EOF
+    run bash "${SCRIPT}" unschedule
+    assert_success
+    grep -qF '0 0 * * * echo ola' "${FAKE_CRONTAB_FILE}"
+}
+
+# ── validação de horário ────────────────────────────────────────────────────
+
+@test "schedule rejeita horário inválido (25:00) com exit 2" {
+    run bash "${SCRIPT}" schedule --daily --at 25:00
+    assert_failure 2
+    assert_output --partial "Horário inválido"
+}
+
+@test "schedule rejeita horário sem dois pontos (0300) com exit 2" {
+    run bash "${SCRIPT}" schedule --daily --at 0300
+    assert_failure 2
+}
+
+@test "schedule --every-days exige N>=2" {
+    run bash "${SCRIPT}" schedule --every-days 1 --at 03:00
+    assert_failure 2
+}
+
+@test "schedule --every-days rejeita N não-numérico" {
+    run bash "${SCRIPT}" schedule --every-days abc --at 03:00
+    assert_failure 2
+}

--- a/tests/unit/test_autoupdate_schedule.bats
+++ b/tests/unit/test_autoupdate_schedule.bats
@@ -171,6 +171,15 @@ EOF
     assert_failure 2
 }
 
+@test "schedule --at seguido de outra flag é rejeitado com a mensagem do --at (F6)" {
+    # Antes, '--at --daily' fazia at="--daily" e só falhava depois com
+    # "Horário inválido" — mensagem confusa. Agora --at rejeita um valor
+    # iniciado por '-' (alinhado com --every-days), com a mensagem correta.
+    run bash "${SCRIPT}" schedule --at --daily
+    assert_failure 2
+    assert_output --partial "--at requer HH:MM."
+}
+
 # ── caminho interativo (regressão B1) ───────────────────────────────────────
 # Sem flags, o schedule entra em prompt interativo. O dispatch passa o array
 # 'rest' vazio aos subcomandos; com "${rest[@]:-}" (sob set -u) isso virava um

--- a/tests/unit/test_autoupdate_schedule.bats
+++ b/tests/unit/test_autoupdate_schedule.bats
@@ -170,3 +170,36 @@ EOF
     run bash "${SCRIPT}" schedule --every-days abc --at 03:00
     assert_failure 2
 }
+
+# ── caminho interativo (regressão B1) ───────────────────────────────────────
+# Sem flags, o schedule entra em prompt interativo. O dispatch passa o array
+# 'rest' vazio aos subcomandos; com "${rest[@]:-}" (sob set -u) isso virava um
+# argumento de string vazia → caía no '*) argumento desconhecido' e o
+# interativo nunca rodava. Estes testes guardam contra essa regressão.
+
+@test "schedule interativo (frequência diária) instala o bloco de cron" {
+    # Stdin: 1=Diária, depois o horário.
+    run bash -c "printf '1\n03:00\n' | bash '${SCRIPT}' schedule"
+    assert_success
+    # Bloco gerenciado instalado com o horário escolhido.
+    grep -qF '# >>> siscan-assistente autoupdate (managed) >>>' "${FAKE_CRONTAB_FILE}"
+    grep -q '^0 3 \* \* \*' "${FAKE_CRONTAB_FILE}"
+    assert_equal "$(jq -r '.schedule.cron' "${STATE_FILE}")" "0 3 * * *"
+    assert_equal "$(jq -r '.schedule.interval_days' "${STATE_FILE}")" "1"
+}
+
+@test "schedule interativo (a cada N dias) instala o bloco com interval_days" {
+    # Stdin: 2=A cada N dias, N=3, horário.
+    run bash -c "printf '2\n3\n04:30\n' | bash '${SCRIPT}' schedule"
+    assert_success
+    grep -q '^30 4 \* \* \*' "${FAKE_CRONTAB_FILE}"
+    assert_equal "$(jq -r '.schedule.interval_days' "${STATE_FILE}")" "3"
+}
+
+@test "schedule interativo rejeita horário inválido com exit 2 e não instala bloco" {
+    run bash -c "printf '1\n25:00\n' | bash '${SCRIPT}' schedule"
+    assert_failure 2
+    assert_output --partial "Horário inválido"
+    # Nenhum bloco gerenciado deve ter sido escrito.
+    ! grep -qF '# >>> siscan-assistente autoupdate (managed) >>>' "${FAKE_CRONTAB_FILE}" 2>/dev/null
+}


### PR DESCRIPTION
## Resumo

Implementa a feature **F00.06** — autoatualização agendada do clone do assistente nas VMs de produção, eliminando o `git pull` manual repetido e expondo um estado auditável da última atualização (commit, timestamp, resultado), inclusive no diagnóstico `pre-deploy` dos workflows CD.

Novo script na raiz: **`siscan-assistente-autoupdate.sh`** (sourceia `scripts/deploy_server/_common.sh`; interface por subcomandos; exit `0`/`2`).

### Subcomandos

- **`run`** (alvo do cron): valida repo git na branch `main`; `git pull --ff-only origin main`; grava estado atômico (`tmp` + `mv`) em UTC ISO-8601. Desfechos: `updated` / `already-current` / `skipped-interval` / `failed`. `--quiet` para cron.
- **`schedule`**: `--daily` | `--every-days N` + `--at HH:MM` (ou prompt interativo). Instala bloco de cron **gerenciado por marcadores**, idempotente. "A cada N dias" via guarda de intervalo no `run` (cron dispara diário).
- **`unschedule`**: remove só o bloco gerenciado, preservando o resto do crontab.
- **`status`**: resumo legível; `--json` (fonte do pre-deploy, `{}` quando ausente).

### Decisões fixadas

- **Árvore suja**: modificação em arquivos **rastreados** → `outcome: failed` + `warn`, **sem** tocar no repo (nunca stasha silenciosamente). Untracked não bloqueia o `--ff-only`. Reconciliação fica com o operador.
- **Estado fora do repo**: `${SISCAN_UPDATE_STATE_FILE:-${XDG_STATE_HOME:-$HOME/.local/state}/siscan-assistente/update-state.json}` (não suja o `git pull`).

### Template (TSK00.06.03)

Step "Anexar estado de autoatualização do assistente" no `pre-deploy` de `cd_imagem_certificada_selfhosted.template.yml`, fundindo `status --json` no `pre-deploy-diag.json` (chave `assistant_update`) via `jq -s`, com fallback `{}`. Só campos sem PII.

### Docs (TSK00.06.04)

Guia `docs/guides/siscan-assistente-autoupdate.md`; seção em `docs/DEPLOY_SERVER.md`; item em `docs/CHECKLISTS.md`; cross-link de `docs/guides/siscan-assistente.md`; `.gitignore` do `update-state.json`.

## Evidência de validação

**shellcheck** (`-x`, seguindo o source):
```
$ shellcheck -x siscan-assistente-autoupdate.sh
shellcheck OK (exit 0)
```
(Sem `-x`, resta apenas SC1091/info — "não segue o arquivo sourceado" — idêntico aos demais scripts do repo. Sem erros.)

**bats** (mesmo runner do CI, `tests/bats/bin/bats`):
```
$ ./tests/bats/bin/bats --formatter tap tests/unit/
1..257   ok=257   not ok=0
```
237 pré-existentes (regressão zero) + 20 novos (`test_autoupdate_run.bats` 8, `test_autoupdate_schedule.bats` 12).

**actionlint** no template (após render de placeholders): exit 0; restam apenas avisos `runner-label` do label self-hosted custom (intrínsecos ao template, não introduzidos por este PR). Nenhum erro de shell/jq no novo step.

## Notas de decisão (defaults adotados sem bloquear)

- O script é um único arquivo cobrindo os 4 subcomandos; o commit do esqueleto + `run` referencia `#106`, com os demais commits cobrindo schedule/template/docs.
- A guarda de intervalo aciona somente quando `interval_days > 1` **e** há `last_success_utc` — assim o primeiro `run` após o `schedule --every-days N` sempre executa.
- Linha de cron exporta `DIR_SISCAN_ASSISTENTE`/`SISCAN_UPDATE_STATE_FILE` explicitamente (ambiente mínimo do cron).

Closes #106
Closes #107
Closes #108
Closes #109