### PR TITLE
refactor(doctor): recursos por produto (#112) + requisitos de host alinhados ao DEPLOY_SERVER.md (#113), sem hardcode

### DIFF
--- a/docs/DEPLOY_SERVER.md
+++ b/docs/DEPLOY_SERVER.md
@@ -96,13 +96,15 @@ O workflow de CD nos produtos consome `siscan-server-doctor.sh` como gate em **p
 
 Antes de provisionar a VM e executar o setup, garanta que ela atende aos requisitos mínimos abaixo. O doctor (próxima seção) valida automaticamente todos eles, mas dimensionamento de hardware/SO precisa ser combinado com a equipe de infraestrutura antes.
 
+Os limiares de recursos (vCPUs, RAM, disco) e de versão (Docker, Compose, Ubuntu, PostgreSQL) verificados pelos specialists têm como fonte única o manifesto `scripts/data/products.json` (`.defaults.resources` e `.defaults.host_requirements`) — esta tabela é a contraparte humana desses valores e deve ser mantida coerente com ele.
+
 ### VM de aplicação (RPA ou Dashboard)
 
 | Requisito | Mínimo | Validado por |
 |---|---|---|
 | Sistema operacional | Ubuntu 24.04 LTS | `check-deps` |
 | vCPUs | 4 | `check-resources` |
-| Memória RAM | 8 GB | `check-resources` |
+| Memória RAM | recomendado 8 GB · piso 7 GB (7–8 GB = aviso, não bloqueia) | `check-resources` |
 | Disco livre em `$COMPOSE_DIR` | 20 GB | `check-resources` |
 | Docker Engine | ≥ 24 (recomendado 28+) | `check-deps` + `check-docker` |
 | Docker Compose | ≥ 2.37 | `check-deps` |

--- a/scripts/data/products.json
+++ b/scripts/data/products.json
@@ -24,7 +24,16 @@
     },
     "default_passwords_to_detect": "Valores de DATABASE_PASSWORD que indicam senha não alterada",
     "extras": "Flags booleanas + defaults consumidos por specialists específicos",
-    "resources": "Limiares mínimos aceitáveis da VM, definidos POR PRODUTO em cada .products.<p>.resources e lidos por check-resources.sh: min_vcpus, min_ram_mb (piso bloqueante), recommended_ram_mb (alvo; entre piso e recomendado = aviso não-bloqueante) e min_disk_gb. Sem hardcode nos scripts (issue #112)."
+    "resources": "Limiares mínimos aceitáveis da VM, definidos POR PRODUTO em cada .products.<p>.resources e lidos por check-resources.sh: min_vcpus, min_ram_mb (piso bloqueante), recommended_ram_mb (alvo; entre piso e recomendado = aviso não-bloqueante) e min_disk_gb. Sem hardcode nos scripts (issue #112).",
+    "defaults": "Requisitos GLOBAIS de host (iguais para todo produto), lidos por check-deps.sh de .defaults.host_requirements: min_docker_major (major mínimo recomendado do Docker Engine), ubuntu_target_major (major alvo testado no DEPLOY_SERVER.md), ubuntu_supported_major (major mínimo ainda suportado; abaixo do alvo = aviso), required_binaries (binários genéricos verificados por check-deps; docker e docker compose são runtime-críticos e verificados com lógica dedicada, usando min_docker_major como limiar). Sem hardcode nos scripts (issue #113)."
+  },
+  "defaults": {
+    "host_requirements": {
+      "min_docker_major": 24,
+      "ubuntu_target_major": 24,
+      "ubuntu_supported_major": 22,
+      "required_binaries": ["curl", "jq", "openssl", "sudo", "timeout", "getent", "git"]
+    }
   },
   "products": {
     "rpa": {

--- a/scripts/data/products.json
+++ b/scripts/data/products.json
@@ -24,10 +24,11 @@
     },
     "default_passwords_to_detect": "Valores de DATABASE_PASSWORD que indicam senha não alterada",
     "extras": "Flags booleanas + defaults consumidos por specialists específicos",
-    "resources": "Limiares mínimos aceitáveis da VM, definidos POR PRODUTO em cada .products.<p>.resources e lidos por check-resources.sh: min_vcpus, min_ram_mb (piso bloqueante), recommended_ram_mb (alvo; entre piso e recomendado = aviso não-bloqueante) e min_disk_gb. Sem hardcode nos scripts (issue #112).",
-    "defaults": "Requisitos GLOBAIS de host (iguais para todo produto), lidos por check-deps.sh de .defaults.host_requirements: min_docker_major (major mínimo recomendado do Docker Engine), ubuntu_target_major (major alvo testado no DEPLOY_SERVER.md), ubuntu_supported_major (major mínimo ainda suportado; abaixo do alvo = aviso), required_binaries (binários genéricos verificados por check-deps; docker e docker compose são runtime-críticos e verificados com lógica dedicada, usando min_docker_major como limiar). Sem hardcode nos scripts (issue #113)."
+    "resources": "Limiares mínimos aceitáveis da VM, lidos por check-resources.sh: min_vcpus, min_ram_mb (piso bloqueante), recommended_ram_mb (alvo; entre piso e recomendado = aviso não-bloqueante) e min_disk_gb. Podem ser definidos POR PRODUTO em .products.<p>.resources; quando ausentes, o specialist cai no fallback GLOBAL .defaults.resources. Sem hardcode nos scripts (issue #112).",
+    "defaults": "Padrões GLOBAIS (iguais para todo produto). .defaults.resources = fallback dos limiares de VM quando o produto não declara .products.<p>.resources (issue #112). .defaults.host_requirements = requisitos de host lidos por check-deps.sh: min_docker_major (major mínimo recomendado do Docker Engine), ubuntu_target_major (major alvo testado no DEPLOY_SERVER.md), ubuntu_supported_major (major mínimo ainda suportado; abaixo do alvo = aviso), required_binaries (binários genéricos verificados por check-deps; docker e docker compose são runtime-críticos e verificados com lógica dedicada, usando min_docker_major como limiar). Sem hardcode nos scripts (issue #113)."
   },
   "defaults": {
+    "resources": { "min_vcpus": 4, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 },
     "host_requirements": {
       "min_docker_major": 24,
       "ubuntu_target_major": 24,

--- a/scripts/data/products.json
+++ b/scripts/data/products.json
@@ -25,12 +25,16 @@
     "default_passwords_to_detect": "Valores de DATABASE_PASSWORD que indicam senha não alterada",
     "extras": "Flags booleanas + defaults consumidos por specialists específicos",
     "resources": "Limiares mínimos aceitáveis da VM, lidos por check-resources.sh: min_vcpus, min_ram_mb (piso bloqueante), recommended_ram_mb (alvo; entre piso e recomendado = aviso não-bloqueante) e min_disk_gb. Podem ser definidos POR PRODUTO em .products.<p>.resources; quando ausentes, o specialist cai no fallback GLOBAL .defaults.resources. Sem hardcode nos scripts (issue #112).",
-    "defaults": "Padrões GLOBAIS (iguais para todo produto). .defaults.resources = fallback dos limiares de VM quando o produto não declara .products.<p>.resources (issue #112). .defaults.host_requirements = requisitos de host lidos por check-deps.sh: min_docker_major (major mínimo recomendado do Docker Engine), ubuntu_target_major (major alvo testado no DEPLOY_SERVER.md), ubuntu_supported_major (major mínimo ainda suportado; abaixo do alvo = aviso), required_binaries (binários genéricos verificados por check-deps; docker e docker compose são runtime-críticos e verificados com lógica dedicada, usando min_docker_major como limiar). Sem hardcode nos scripts (issue #113)."
+    "defaults": "Padrões GLOBAIS (iguais para todo produto). .defaults.resources = fallback dos limiares de VM quando o produto não declara .products.<p>.resources (issue #112). .defaults.host_requirements = requisitos de host da tabela de pré-requisitos do DEPLOY_SERVER.md, lidos pelos specialists: min_docker_major (piso) e recommended_docker_major (alvo; entre piso e alvo = aviso) — check-deps; min_compose_version (versão mínima do plugin Docker Compose, comparada com sort -V; abaixo = aviso) — check-deps; min_postgres_major (alvo) e supported_postgres_major (piso funcional; abaixo do piso = fail) — check-db via SHOW server_version; ubuntu_target_major (alvo) e ubuntu_supported_major (mínimo ainda suportado; abaixo do alvo = aviso) — check-deps; required_binaries (binários genéricos verificados por check-deps; docker e docker compose são runtime-críticos e verificados com lógica dedicada). Sem hardcode nos scripts (issue #113)."
   },
   "defaults": {
     "resources": { "min_vcpus": 4, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 },
     "host_requirements": {
       "min_docker_major": 24,
+      "recommended_docker_major": 28,
+      "min_compose_version": "2.37",
+      "min_postgres_major": 16,
+      "supported_postgres_major": 14,
       "ubuntu_target_major": 24,
       "ubuntu_supported_major": 22,
       "required_binaries": ["curl", "jq", "openssl", "sudo", "timeout", "getent", "git"]

--- a/scripts/data/products.json
+++ b/scripts/data/products.json
@@ -23,7 +23,8 @@
       "description": "Descrição amigável para exibir no setup interativo."
     },
     "default_passwords_to_detect": "Valores de DATABASE_PASSWORD que indicam senha não alterada",
-    "extras": "Flags booleanas + defaults consumidos por specialists específicos"
+    "extras": "Flags booleanas + defaults consumidos por specialists específicos",
+    "resources": "Limiares mínimos aceitáveis da VM, definidos POR PRODUTO em cada .products.<p>.resources e lidos por check-resources.sh: min_vcpus, min_ram_mb (piso bloqueante), recommended_ram_mb (alvo; entre piso e recomendado = aviso não-bloqueante) e min_disk_gb. Sem hardcode nos scripts (issue #112)."
   },
   "products": {
     "rpa": {
@@ -34,6 +35,7 @@
       "env_sample": ".env.server-rpa.sample",
       "runner_label": "producao-rpa",
       "runner_name_suffix": "siscan-rpa",
+      "resources": { "min_vcpus": 4, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 },
       "session_secret_var": "SECRET_KEY",
       "expected_services": ["app", "rpa-scheduler"],
       "expected_external_ports": [5001],
@@ -84,6 +86,7 @@
       "env_sample": ".env.server-dashboard.sample",
       "runner_label": "producao-dashboard",
       "runner_name_suffix": "siscan-dashboard",
+      "resources": { "min_vcpus": 4, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 },
       "session_secret_var": "SESSION_SECRET",
       "expected_services": ["app", "sync", "redis"],
       "expected_external_ports": [5000],
@@ -117,6 +120,7 @@
       "env_sample": ".env.host.sample",
       "runner_label": "(modo HOST não usa runner)",
       "runner_name_suffix": "siscan-full",
+      "resources": { "min_vcpus": 4, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 },
       "session_secret_var": "SECRET_KEY",
       "expected_services": ["db", "app", "rpa-scheduler"],
       "expected_external_ports": [5000, 5001],

--- a/scripts/data/products.json
+++ b/scripts/data/products.json
@@ -24,7 +24,7 @@
     },
     "default_passwords_to_detect": "Valores de DATABASE_PASSWORD que indicam senha não alterada",
     "extras": "Flags booleanas + defaults consumidos por specialists específicos",
-    "resources": "Limiares mínimos aceitáveis da VM, lidos por check-resources.sh: min_vcpus, min_ram_mb (piso bloqueante), recommended_ram_mb (alvo; entre piso e recomendado = aviso não-bloqueante) e min_disk_gb. Podem ser definidos POR PRODUTO em .products.<p>.resources; quando ausentes, o specialist cai no fallback GLOBAL .defaults.resources. Sem hardcode nos scripts (issue #112).",
+    "resources": "Limiares mínimos aceitáveis da VM, lidos por check-resources.sh: min_vcpus, min_ram_mb (piso bloqueante), recommended_ram_mb (alvo; entre piso e recomendado = aviso não-bloqueante) e min_disk_gb. Declarados GLOBALMENTE em .defaults.resources (iguais para todo produto hoje). Override OPCIONAL por produto em .products.<p>.resources APENAS quando um produto realmente divergir — declare só então (YAGNI; check-resources é product-agnostic e usa .defaults quando o produto não declara). Sem hardcode nos scripts (issue #112).",
     "defaults": "Padrões GLOBAIS (iguais para todo produto). .defaults.resources = fallback dos limiares de VM quando o produto não declara .products.<p>.resources (issue #112). .defaults.host_requirements = requisitos de host da tabela de pré-requisitos do DEPLOY_SERVER.md, lidos pelos specialists: min_docker_major (piso) e recommended_docker_major (alvo; entre piso e alvo = aviso) — check-deps; min_compose_version (versão mínima do plugin Docker Compose, comparada com sort -V; abaixo = aviso) — check-deps; min_postgres_major (alvo) e supported_postgres_major (piso funcional; abaixo do piso = fail) — check-db via SHOW server_version; ubuntu_target_major (alvo) e ubuntu_supported_major (mínimo ainda suportado; abaixo do alvo = aviso) — check-deps; required_binaries (binários genéricos verificados por check-deps; docker e docker compose são runtime-críticos e verificados com lógica dedicada). Sem hardcode nos scripts (issue #113)."
   },
   "defaults": {
@@ -49,7 +49,6 @@
       "env_sample": ".env.server-rpa.sample",
       "runner_label": "producao-rpa",
       "runner_name_suffix": "siscan-rpa",
-      "resources": { "min_vcpus": 4, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 },
       "session_secret_var": "SECRET_KEY",
       "expected_services": ["app", "rpa-scheduler"],
       "expected_external_ports": [5001],
@@ -100,7 +99,6 @@
       "env_sample": ".env.server-dashboard.sample",
       "runner_label": "producao-dashboard",
       "runner_name_suffix": "siscan-dashboard",
-      "resources": { "min_vcpus": 4, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 },
       "session_secret_var": "SESSION_SECRET",
       "expected_services": ["app", "sync", "redis"],
       "expected_external_ports": [5000],
@@ -134,7 +132,6 @@
       "env_sample": ".env.host.sample",
       "runner_label": "(modo HOST não usa runner)",
       "runner_name_suffix": "siscan-full",
-      "resources": { "min_vcpus": 4, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 },
       "session_secret_var": "SECRET_KEY",
       "expected_services": ["db", "app", "rpa-scheduler"],
       "expected_external_ports": [5000, 5001],

--- a/scripts/deploy_server/_common.sh
+++ b/scripts/deploy_server/_common.sh
@@ -471,6 +471,14 @@ product_get_host_dir_vars_derived() {
         | @tsv' "$PRODUCTS_FILE" 2>/dev/null
 }
 
+# hostreq KEY
+#   Lê .defaults.host_requirements.KEY do manifesto (requisitos de host GLOBAIS,
+#   iguais para todo produto — issue #113). Emite vazio se jq/manifesto ausentes
+#   ou chave inexistente; o caller aplica fallback de bootstrap (: "${VAR:=…}").
+#   Usa `// empty` (não `// 0`) pra preservar o valor 0 e permitir o fallback
+#   distinguir "ausente" de "zero". Requer PRODUCTS_FILE definido pelo specialist.
+hostreq() { jq -r ".defaults.host_requirements.$1 // empty" "$PRODUCTS_FILE" 2>/dev/null; }
+
 # product_has_extra KEY
 #   Retorna 0 se extras.KEY == true, 1 caso contrário.
 product_has_extra() {

--- a/scripts/deploy_server/check-db.sh
+++ b/scripts/deploy_server/check-db.sh
@@ -22,7 +22,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$SCRIPT_DIR/_common.sh"
 
 ENV_FILE="${COMPOSE_DIR:-$(pwd)}/.env"
-PRODUCTS_FILE="${REPO_ROOT}/scripts/data/products.json"
+# PRODUCTS_FILE overridável por env (testabilidade); default = manifesto do repo.
+PRODUCTS_FILE="${PRODUCTS_FILE:-${REPO_ROOT}/scripts/data/products.json}"
 # Defaults de conveniência — avaliados na issue #113 e MANTIDOS no specialist
 # (não migrados ao products.json) por já serem configuráveis e não variarem por
 # produto: TIMEOUT_SEC é sobrescrevível por --timeout; a porta do Postgres é
@@ -34,12 +35,13 @@ TIMEOUT_SEC=5
 # (.defaults.host_requirements, issue #113) — NÃO hardcoded. min_postgres_major =
 # alvo; supported_postgres_major = piso funcional (abaixo => fail). Fallback de
 # bootstrap (jq ausente / manifesto ilegível) em paridade com o manifesto.
-_hostreq() { jq -r ".defaults.host_requirements.$1 // empty" "$PRODUCTS_FILE" 2>/dev/null; }
+# hostreq (lê .defaults.host_requirements.KEY) vem de _common.sh (#113) — evita
+# duplicar a função idêntica em check-deps e check-db.
 MIN_PG_MAJOR=""
 SUPPORTED_PG_MAJOR=""
 if command -v jq >/dev/null 2>&1 && [ -f "$PRODUCTS_FILE" ]; then
-    MIN_PG_MAJOR=$(_hostreq min_postgres_major)
-    SUPPORTED_PG_MAJOR=$(_hostreq supported_postgres_major)
+    MIN_PG_MAJOR=$(hostreq min_postgres_major)
+    SUPPORTED_PG_MAJOR=$(hostreq supported_postgres_major)
 fi
 : "${MIN_PG_MAJOR:=16}"
 : "${SUPPORTED_PG_MAJOR:=14}"
@@ -121,7 +123,7 @@ _check_db_target() {
             if [ "$ver_major" -ge "$MIN_PG_MAJOR" ] 2>/dev/null; then
                 add_ok "$category" pg "$port" "${host}/${db}" "PostgreSQL $ver_raw (>= ${MIN_PG_MAJOR})"
             elif [ "$ver_major" -ge "$SUPPORTED_PG_MAJOR" ] 2>/dev/null; then
-                add_ok "$category" pg "$port" "${host}/${db}" "PostgreSQL $ver_raw (anterior ao alvo ${MIN_PG_MAJOR} mas funcional)"
+                add_ok "$category" pg "$port" "${host}/${db}" "PostgreSQL $ver_raw (anterior ao alvo ${MIN_PG_MAJOR}, acima do piso ${SUPPORTED_PG_MAJOR} — funcional)"
             else
                 add_fail "$category" pg "$port" "${host}/${db}" "PostgreSQL $ver_raw muito antigo — DEPLOY_SERVER.md exige >= ${MIN_PG_MAJOR}"
             fi

--- a/scripts/deploy_server/check-db.sh
+++ b/scripts/deploy_server/check-db.sh
@@ -30,6 +30,20 @@ PRODUCTS_FILE="${REPO_ROOT}/scripts/data/products.json"
 # projeto usam a porta padrão 5432/TCP, então externalizar não agregaria.
 TIMEOUT_SEC=5
 
+# Limiar de versão do PostgreSQL: lido do manifesto global
+# (.defaults.host_requirements, issue #113) — NÃO hardcoded. min_postgres_major =
+# alvo; supported_postgres_major = piso funcional (abaixo => fail). Fallback de
+# bootstrap (jq ausente / manifesto ilegível) em paridade com o manifesto.
+_hostreq() { jq -r ".defaults.host_requirements.$1 // empty" "$PRODUCTS_FILE" 2>/dev/null; }
+MIN_PG_MAJOR=""
+SUPPORTED_PG_MAJOR=""
+if command -v jq >/dev/null 2>&1 && [ -f "$PRODUCTS_FILE" ]; then
+    MIN_PG_MAJOR=$(_hostreq min_postgres_major)
+    SUPPORTED_PG_MAJOR=$(_hostreq supported_postgres_major)
+fi
+: "${MIN_PG_MAJOR:=16}"
+: "${SUPPORTED_PG_MAJOR:=14}"
+
 usage() {
     cat <<EOF
 Uso: bash $(basename "$0") [--env-file FILE] [--product NAME] [--timeout SEC] [--quiet | --json] [--help]
@@ -97,19 +111,19 @@ _check_db_target() {
         info "pg_isready ausente (apt install postgresql-client) — validação restrita a TCP/$port"
     fi
 
-    # Versão do PostgreSQL (DEPLOY_SERVER.md pré-req: >= 16). Requer psql + senha.
-    # Skip controlado se psql ausente ou senha vazia.
+    # Versão do PostgreSQL (limiar do manifesto, DEPLOY_SERVER.md pré-req).
+    # Requer psql + senha. Skip controlado se psql ausente ou senha vazia.
     if command -v psql >/dev/null 2>&1 && [ -n "$password" ] && [ -n "$user" ] && [ -n "$db" ]; then
         ver_raw=$(PGPASSWORD="$password" psql -h "$host" -p "$port" -U "$user" -d "$db" \
                     -tAc "SHOW server_version" 2>/dev/null | head -1)
         if [ -n "$ver_raw" ]; then
             ver_major=$(echo "$ver_raw" | cut -d. -f1)
-            if [ "$ver_major" -ge 16 ] 2>/dev/null; then
-                add_ok "$category" pg "$port" "${host}/${db}" "PostgreSQL $ver_raw (>= 16)"
-            elif [ "$ver_major" -ge 14 ] 2>/dev/null; then
-                add_ok "$category" pg "$port" "${host}/${db}" "PostgreSQL $ver_raw (anterior ao alvo 16 mas funcional)"
+            if [ "$ver_major" -ge "$MIN_PG_MAJOR" ] 2>/dev/null; then
+                add_ok "$category" pg "$port" "${host}/${db}" "PostgreSQL $ver_raw (>= ${MIN_PG_MAJOR})"
+            elif [ "$ver_major" -ge "$SUPPORTED_PG_MAJOR" ] 2>/dev/null; then
+                add_ok "$category" pg "$port" "${host}/${db}" "PostgreSQL $ver_raw (anterior ao alvo ${MIN_PG_MAJOR} mas funcional)"
             else
-                add_fail "$category" pg "$port" "${host}/${db}" "PostgreSQL $ver_raw muito antigo — DEPLOY_SERVER.md exige >= 16"
+                add_fail "$category" pg "$port" "${host}/${db}" "PostgreSQL $ver_raw muito antigo — DEPLOY_SERVER.md exige >= ${MIN_PG_MAJOR}"
             fi
         else
             info "psql disponível mas SHOW server_version falhou (auth/network?) — versão não verificada"

--- a/scripts/deploy_server/check-db.sh
+++ b/scripts/deploy_server/check-db.sh
@@ -23,6 +23,11 @@ source "$SCRIPT_DIR/_common.sh"
 
 ENV_FILE="${COMPOSE_DIR:-$(pwd)}/.env"
 PRODUCTS_FILE="${REPO_ROOT}/scripts/data/products.json"
+# Defaults de conveniência — avaliados na issue #113 e MANTIDOS no specialist
+# (não migrados ao products.json) por já serem configuráveis e não variarem por
+# produto: TIMEOUT_SEC é sobrescrevível por --timeout; a porta do Postgres é
+# lida do .env (DATABASE_PORT, default 5432 logo abaixo) — todos os bancos do
+# projeto usam a porta padrão 5432/TCP, então externalizar não agregaria.
 TIMEOUT_SEC=5
 
 usage() {

--- a/scripts/deploy_server/check-deps.sh
+++ b/scripts/deploy_server/check-deps.sh
@@ -14,6 +14,8 @@ set -uo pipefail
 
 SPECIALIST_NAME="check-deps"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PRODUCTS_FILE="${REPO_ROOT}/scripts/data/products.json"
 
 # shellcheck source=./_common.sh
 source "$SCRIPT_DIR/_common.sh"
@@ -38,6 +40,38 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+# ────────────────────────────────────────────────────────────────────────────
+# Requisitos de host (GLOBAIS — iguais para todo produto). Fonte única da
+# verdade: scripts/data/products.json (.defaults.host_requirements). NÃO há
+# limiares hardcoded como configuração (issue #113).
+#
+# Bootstrap: check-deps é justamente o specialist que detecta jq ausente. Sem
+# jq o manifesto é ilegível — então mantemos um fallback mínimo (idêntico aos
+# valores do manifesto) só pra não travar o diagnóstico nesse cenário; o próprio
+# jq ausente já é reportado como FAIL na seção Network tools abaixo.
+# ────────────────────────────────────────────────────────────────────────────
+_hostreq() { jq -r ".defaults.host_requirements.$1 // empty" "$PRODUCTS_FILE" 2>/dev/null; }
+MIN_DOCKER_MAJOR=""
+UBUNTU_TARGET_MAJOR=""
+UBUNTU_SUPPORTED_MAJOR=""
+REQUIRED_BINARIES=()
+if command -v jq >/dev/null 2>&1 && [ -f "$PRODUCTS_FILE" ]; then
+    MIN_DOCKER_MAJOR=$(_hostreq min_docker_major)
+    UBUNTU_TARGET_MAJOR=$(_hostreq ubuntu_target_major)
+    UBUNTU_SUPPORTED_MAJOR=$(_hostreq ubuntu_supported_major)
+    while IFS= read -r _bin; do
+        [ -n "$_bin" ] && REQUIRED_BINARIES+=("$_bin")
+    done < <(jq -r '.defaults.host_requirements.required_binaries[]? // empty' "$PRODUCTS_FILE" 2>/dev/null)
+fi
+# Fallback de bootstrap (jq ausente / manifesto ilegível) — modo degradado, não
+# é a fonte da verdade; mantém os valores em paridade com o manifesto.
+: "${MIN_DOCKER_MAJOR:=24}"
+: "${UBUNTU_TARGET_MAJOR:=24}"
+: "${UBUNTU_SUPPORTED_MAJOR:=22}"
+if [ "${#REQUIRED_BINARIES[@]}" -eq 0 ]; then
+    REQUIRED_BINARIES=(curl jq openssl sudo timeout getent git)
+fi
 
 CAT_RUNTIME="Container runtime (Docker)"
 CAT_NETWORK="Network tools"
@@ -65,10 +99,10 @@ if command -v docker >/dev/null 2>&1; then
     docker_ver=$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo "")
     if [ -n "$docker_ver" ]; then
         major=$(echo "$docker_ver" | cut -d. -f1)
-        if [ "$major" -ge 24 ] 2>/dev/null; then
+        if [ "$major" -ge "$MIN_DOCKER_MAJOR" ] 2>/dev/null; then
             add_ok "$CAT_RUNTIME" cmd 0 "docker" "$docker_ver"
         else
-            add_ok "$CAT_RUNTIME" cmd 0 "docker" "$docker_ver (recomendado >= 24)"
+            add_ok "$CAT_RUNTIME" cmd 0 "docker" "$docker_ver (recomendado >= ${MIN_DOCKER_MAJOR})"
         fi
     else
         add_fail "$CAT_RUNTIME" cmd 0 "docker" "daemon não acessível"
@@ -84,22 +118,58 @@ else
     add_fail "$CAT_RUNTIME" cmd 0 "docker compose" "plugin v2 ausente — sudo apt install docker-compose-plugin"
 fi
 
-# Network tools
-print_category_header "$CAT_NETWORK" "Ferramentas usadas pelo check-network e por scripts de geração de chave/manipulação de JSON."
-_check_bin "$CAT_NETWORK" curl    "curl --version | head -1 | awk '{print \$2}'"
-_check_bin "$CAT_NETWORK" jq      "jq --version | head -1"
-_check_bin "$CAT_NETWORK" openssl "openssl version | awk '{print \$2}'"
+# Binários genéricos: QUAIS verificar vem do manifesto
+# (.defaults.host_requirements.required_binaries, #113). A categoria e o comando
+# de versão de cada um são apresentação/lógica de shell — ficam no specialist,
+# resolvidos por nome. Imprime o cabeçalho da categoria quando ela muda
+# (a ordem do manifesto agrupa por categoria).
+_bin_category() {
+    case "$1" in
+        curl|jq|openssl)         echo "$CAT_NETWORK" ;;
+        sudo|timeout|getent|git) echo "$CAT_SYSTEM" ;;
+        *)                       echo "" ;;
+    esac
+}
+_bin_version_cmd() {
+    case "$1" in
+        curl)    echo "curl --version | head -1 | awk '{print \$2}'" ;;
+        jq)      echo "jq --version | head -1" ;;
+        openssl) echo "openssl version | awk '{print \$2}'" ;;
+        sudo)    echo "sudo --version | head -1 | awk '{print \$3}'" ;;
+        timeout) echo "timeout --version | head -1 | awk '{print \$NF}'" ;;
+        git)     echo "git --version | awk '{print \$3}'" ;;
+        getent)  echo "" ;;
+        *)       echo "" ;;
+    esac
+}
+_cat_desc() {
+    case "$1" in
+        "$CAT_NETWORK") echo "Ferramentas usadas pelo check-network e por scripts de geração de chave/manipulação de JSON." ;;
+        "$CAT_SYSTEM")  echo "Comandos básicos usados pelo siscan-server-setup.sh e pelos specialists." ;;
+        *)              echo "" ;;
+    esac
+}
 
-# Sistema
-print_category_header "$CAT_SYSTEM" "Comandos básicos usados pelo siscan-server-setup.sh e pelos specialists."
-_check_bin "$CAT_SYSTEM" sudo    "sudo --version | head -1 | awk '{print \$3}'"
-_check_bin "$CAT_SYSTEM" timeout "timeout --version | head -1 | awk '{print \$NF}'"
-_check_bin "$CAT_SYSTEM" getent  ""
-_check_bin "$CAT_SYSTEM" git     "git --version | awk '{print \$3}'"
+_last_cat=""
+for _bin in "${REQUIRED_BINARIES[@]}"; do
+    _cat="$(_bin_category "$_bin")"
+    if [ -z "$_cat" ]; then
+        # Binário exigido no manifesto sem rotina de verificação aqui: drift
+        # entre products.json e o specialist — reporta como FAIL na categoria Sistema.
+        [ "$_last_cat" = "$CAT_SYSTEM" ] || { print_category_header "$CAT_SYSTEM" "$(_cat_desc "$CAT_SYSTEM")"; _last_cat="$CAT_SYSTEM"; }
+        add_fail "$CAT_SYSTEM" cmd 0 "$_bin" "exigido em .defaults.host_requirements.required_binaries (products.json) mas sem rotina de verificação no check-deps — drift manifesto↔specialist (#113)"
+        continue
+    fi
+    if [ "$_cat" != "$_last_cat" ]; then
+        print_category_header "$_cat" "$(_cat_desc "$_cat")"
+        _last_cat="$_cat"
+    fi
+    _check_bin "$_cat" "$_bin" "$(_bin_version_cmd "$_bin")"
+done
 
-# Sistema operacional (DEPLOY_SERVER.md pré-req: Ubuntu 24.04 LTS)
+# Sistema operacional — alvo lido do manifesto (.defaults.host_requirements, #113)
 CAT_OS="Sistema operacional"
-print_category_header "$CAT_OS" "Ubuntu 24.04 LTS é o alvo testado no DEPLOY_SERVER.md — versões mais antigas podem ter Docker/Compose desatualizados."
+print_category_header "$CAT_OS" "Ubuntu ${UBUNTU_TARGET_MAJOR}.04 LTS é o alvo testado no DEPLOY_SERVER.md — versões mais antigas podem ter Docker/Compose desatualizados."
 os_id=""
 os_ver=""
 if [ -f /etc/os-release ]; then
@@ -111,17 +181,17 @@ fi
 if [ -z "$os_id" ]; then
     add_fail "$CAT_OS" os 0 "OS" "/etc/os-release ausente — não dá pra identificar a distro"
 elif [ "$os_id" = "ubuntu" ]; then
-    # Compara major version (24, 22, 20...)
+    # Compara major version (24, 22, 20...) contra os limiares do manifesto
     os_major="${os_ver%%.*}"
-    if [ "$os_major" -ge 24 ] 2>/dev/null; then
+    if [ "$os_major" -ge "$UBUNTU_TARGET_MAJOR" ] 2>/dev/null; then
         add_ok "$CAT_OS" os 0 "Ubuntu $os_ver" "alvo do DEPLOY_SERVER.md"
-    elif [ "$os_major" -ge 22 ] 2>/dev/null; then
-        add_ok "$CAT_OS" os 0 "Ubuntu $os_ver" "anterior ao alvo (24.04) mas suportado — pode ter Docker/Compose desatualizados"
+    elif [ "$os_major" -ge "$UBUNTU_SUPPORTED_MAJOR" ] 2>/dev/null; then
+        add_ok "$CAT_OS" os 0 "Ubuntu $os_ver" "anterior ao alvo (${UBUNTU_TARGET_MAJOR}.04) mas suportado — pode ter Docker/Compose desatualizados"
     else
-        add_fail "$CAT_OS" os 0 "Ubuntu $os_ver" "muito antiga — DEPLOY_SERVER.md exige 24.04 LTS"
+        add_fail "$CAT_OS" os 0 "Ubuntu $os_ver" "muito antiga — DEPLOY_SERVER.md exige >= ${UBUNTU_TARGET_MAJOR}.04 LTS"
     fi
 else
-    add_fail "$CAT_OS" os 0 "$os_id $os_ver" "distro não testada — DEPLOY_SERVER.md exige Ubuntu 24.04 LTS"
+    add_fail "$CAT_OS" os 0 "$os_id $os_ver" "distro não testada — DEPLOY_SERVER.md exige Ubuntu ${UBUNTU_TARGET_MAJOR}.04 LTS"
 fi
 
 # Sincronização de tempo

--- a/scripts/deploy_server/check-deps.sh
+++ b/scripts/deploy_server/check-deps.sh
@@ -53,11 +53,15 @@ done
 # ────────────────────────────────────────────────────────────────────────────
 _hostreq() { jq -r ".defaults.host_requirements.$1 // empty" "$PRODUCTS_FILE" 2>/dev/null; }
 MIN_DOCKER_MAJOR=""
+RECOMMENDED_DOCKER_MAJOR=""
+MIN_COMPOSE_VERSION=""
 UBUNTU_TARGET_MAJOR=""
 UBUNTU_SUPPORTED_MAJOR=""
 REQUIRED_BINARIES=()
 if command -v jq >/dev/null 2>&1 && [ -f "$PRODUCTS_FILE" ]; then
     MIN_DOCKER_MAJOR=$(_hostreq min_docker_major)
+    RECOMMENDED_DOCKER_MAJOR=$(_hostreq recommended_docker_major)
+    MIN_COMPOSE_VERSION=$(_hostreq min_compose_version)
     UBUNTU_TARGET_MAJOR=$(_hostreq ubuntu_target_major)
     UBUNTU_SUPPORTED_MAJOR=$(_hostreq ubuntu_supported_major)
     while IFS= read -r _bin; do
@@ -67,6 +71,8 @@ fi
 # Fallback de bootstrap (jq ausente / manifesto ilegível) — modo degradado, não
 # é a fonte da verdade; mantém os valores em paridade com o manifesto.
 : "${MIN_DOCKER_MAJOR:=24}"
+: "${RECOMMENDED_DOCKER_MAJOR:=28}"
+: "${MIN_COMPOSE_VERSION:=2.37}"
 : "${UBUNTU_TARGET_MAJOR:=24}"
 : "${UBUNTU_SUPPORTED_MAJOR:=22}"
 if [ "${#REQUIRED_BINARIES[@]}" -eq 0 ]; then
@@ -98,11 +104,15 @@ print_category_header "$CAT_RUNTIME" "Docker Engine e plugin Compose v2 — pré
 if command -v docker >/dev/null 2>&1; then
     docker_ver=$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo "")
     if [ -n "$docker_ver" ]; then
+        # Camadas (manifesto): >= recomendado (alvo) ok; entre piso e alvo = aviso;
+        # abaixo do piso = aviso mais forte (advisory — versão não bloqueia o deploy).
         major=$(echo "$docker_ver" | cut -d. -f1)
-        if [ "$major" -ge "$MIN_DOCKER_MAJOR" ] 2>/dev/null; then
+        if [ "$major" -ge "$RECOMMENDED_DOCKER_MAJOR" ] 2>/dev/null; then
             add_ok "$CAT_RUNTIME" cmd 0 "docker" "$docker_ver"
+        elif [ "$major" -ge "$MIN_DOCKER_MAJOR" ] 2>/dev/null; then
+            add_ok "$CAT_RUNTIME" cmd 0 "docker" "$docker_ver (warn) — atende o piso ${MIN_DOCKER_MAJOR}, recomendado >= ${RECOMMENDED_DOCKER_MAJOR}"
         else
-            add_ok "$CAT_RUNTIME" cmd 0 "docker" "$docker_ver (recomendado >= ${MIN_DOCKER_MAJOR})"
+            add_ok "$CAT_RUNTIME" cmd 0 "docker" "$docker_ver (warn) — abaixo do piso ${MIN_DOCKER_MAJOR}; recomendado >= ${RECOMMENDED_DOCKER_MAJOR}"
         fi
     else
         add_fail "$CAT_RUNTIME" cmd 0 "docker" "daemon não acessível"
@@ -112,8 +122,19 @@ else
 fi
 
 if docker compose version >/dev/null 2>&1; then
-    compose_ver=$(docker compose version --short 2>/dev/null || echo "presente")
-    add_ok "$CAT_RUNTIME" cmd 0 "docker compose" "$compose_ver"
+    compose_ver=$(docker compose version --short 2>/dev/null || echo "")
+    if [ -z "$compose_ver" ]; then
+        add_ok "$CAT_RUNTIME" cmd 0 "docker compose" "presente (versão não detectável)"
+    else
+        # Compara com o piso do manifesto via sort -V (lida com sufixos tipo
+        # 2.38.1-desktop.1). Abaixo do piso = aviso não-bloqueante.
+        compose_num="${compose_ver#v}"
+        if [ "$(printf '%s\n%s\n' "$MIN_COMPOSE_VERSION" "$compose_num" | sort -V | head -1)" = "$MIN_COMPOSE_VERSION" ]; then
+            add_ok "$CAT_RUNTIME" cmd 0 "docker compose" "$compose_ver (>= ${MIN_COMPOSE_VERSION})"
+        else
+            add_ok "$CAT_RUNTIME" cmd 0 "docker compose" "$compose_ver (warn) — abaixo do recomendado ${MIN_COMPOSE_VERSION}"
+        fi
+    fi
 else
     add_fail "$CAT_RUNTIME" cmd 0 "docker compose" "plugin v2 ausente — sudo apt install docker-compose-plugin"
 fi

--- a/scripts/deploy_server/check-deps.sh
+++ b/scripts/deploy_server/check-deps.sh
@@ -15,7 +15,8 @@ set -uo pipefail
 SPECIALIST_NAME="check-deps"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-PRODUCTS_FILE="${REPO_ROOT}/scripts/data/products.json"
+# PRODUCTS_FILE overridável por env (testabilidade); default = manifesto do repo.
+PRODUCTS_FILE="${PRODUCTS_FILE:-${REPO_ROOT}/scripts/data/products.json}"
 
 # shellcheck source=./_common.sh
 source "$SCRIPT_DIR/_common.sh"
@@ -24,8 +25,12 @@ usage() {
     cat <<EOF
 Uso: bash $(basename "$0") [--quiet | --json] [--help]
 
-Verifica disponibilidade local de: docker, docker compose, curl, jq,
-sudo, openssl, timeout, getent, e sincronização NTP do relógio.
+Verifica versão do Docker Engine e do plugin Docker Compose (comparada com o
+piso do manifesto), a versão do Ubuntu, a sincronização NTP do relógio e a
+disponibilidade dos binários genéricos exigidos. A lista de binários e os
+limiares de versão vêm de scripts/data/products.json
+(.defaults.host_requirements: required_binaries, min/recommended_docker_major,
+min_compose_version, ubuntu_target/supported_major).
 
 Exit code: 0 = OK · 1 = pelo menos uma dependência ausente · 2 = uso inválido
 EOF
@@ -51,7 +56,8 @@ done
 # valores do manifesto) só pra não travar o diagnóstico nesse cenário; o próprio
 # jq ausente já é reportado como FAIL na seção Network tools abaixo.
 # ────────────────────────────────────────────────────────────────────────────
-_hostreq() { jq -r ".defaults.host_requirements.$1 // empty" "$PRODUCTS_FILE" 2>/dev/null; }
+# hostreq (lê .defaults.host_requirements.KEY) vem de _common.sh (#113) — evita
+# duplicar a função idêntica em check-deps e check-db.
 MIN_DOCKER_MAJOR=""
 RECOMMENDED_DOCKER_MAJOR=""
 MIN_COMPOSE_VERSION=""
@@ -59,11 +65,11 @@ UBUNTU_TARGET_MAJOR=""
 UBUNTU_SUPPORTED_MAJOR=""
 REQUIRED_BINARIES=()
 if command -v jq >/dev/null 2>&1 && [ -f "$PRODUCTS_FILE" ]; then
-    MIN_DOCKER_MAJOR=$(_hostreq min_docker_major)
-    RECOMMENDED_DOCKER_MAJOR=$(_hostreq recommended_docker_major)
-    MIN_COMPOSE_VERSION=$(_hostreq min_compose_version)
-    UBUNTU_TARGET_MAJOR=$(_hostreq ubuntu_target_major)
-    UBUNTU_SUPPORTED_MAJOR=$(_hostreq ubuntu_supported_major)
+    MIN_DOCKER_MAJOR=$(hostreq min_docker_major)
+    RECOMMENDED_DOCKER_MAJOR=$(hostreq recommended_docker_major)
+    MIN_COMPOSE_VERSION=$(hostreq min_compose_version)
+    UBUNTU_TARGET_MAJOR=$(hostreq ubuntu_target_major)
+    UBUNTU_SUPPORTED_MAJOR=$(hostreq ubuntu_supported_major)
     while IFS= read -r _bin; do
         [ -n "$_bin" ] && REQUIRED_BINARIES+=("$_bin")
     done < <(jq -r '.defaults.host_requirements.required_binaries[]? // empty' "$PRODUCTS_FILE" 2>/dev/null)

--- a/scripts/deploy_server/check-docker.sh
+++ b/scripts/deploy_server/check-docker.sh
@@ -14,6 +14,12 @@
 #   - /var/run/docker.sock existe
 #   - daemon.json: pool size sane (se configurado)
 #   - TESTE REAL: docker network create teste && rm teste (gold standard)
+#
+# Convenções padrão do Docker — avaliadas na issue #113 e MANTIDAS no specialist
+# (não externalizadas ao products.json): /var/run/docker.sock, /etc/docker/daemon.json
+# e o pool default 172.17.0.0/16 são caminhos/convenções fixas do próprio Docker,
+# idênticos em qualquer host e produto. Não variam por produto — externalizar não
+# agregaria.
 # -------------------------------------------
 
 set -uo pipefail

--- a/scripts/deploy_server/check-resources.sh
+++ b/scripts/deploy_server/check-resources.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 # -------------------------------------------
 # Specialist: check-resources
-# Summary: vCPUs, RAM e disco livre — limiares POR PRODUTO em products.json
+# Summary: vCPUs, RAM e disco livre — limiares GLOBAIS em products.json
 # -------------------------------------------
 # Verifica que a VM atende aos requisitos de capacidade declarados no manifesto
-# scripts/data/products.json (.products.<p>.resources, com fallback ao mínimo
-# aceitável GLOBAL .defaults.resources): min_vcpus, min_ram_mb (piso),
-# recommended_ram_mb (alvo; entre piso e recomendado = aviso) e min_disk_gb.
-# NÃO há limiar hardcoded aqui.
+# scripts/data/products.json (.defaults.resources, com override POR PRODUTO em
+# .products.<p>.resources QUANDO o produto for resolvível): min_vcpus,
+# min_ram_mb (piso), recommended_ram_mb (alvo; entre piso e recomendado = aviso)
+# e min_disk_gb. NÃO há limiar hardcoded como configuração — apenas um fallback
+# de bootstrap (jq/manifesto ausentes) em paridade com o manifesto.
+#
+# É PRODUCT-AGNOSTIC: roda sempre, mesmo sem --product/SISCAN_PRODUCT (mede
+# CPU/RAM/disco, que não dependem de produto). Resolver produto é best-effort —
+# se houver produto resolvido E declarando .resources, sobrepõe os defaults;
+# caso contrário usa .defaults.resources. Nunca aborta por produto ausente.
 #
 # Em VMs com menos recursos a stack até sobe, mas:
 #   - migrate + app + scheduler + redis disputam CPU em pull/up;
@@ -24,25 +30,29 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # shellcheck source=./_common.sh
 source "$SCRIPT_DIR/_common.sh"
 
-PRODUCTS_FILE="${REPO_ROOT}/scripts/data/products.json"
+# PRODUCTS_FILE é overridável por env (testabilidade) — default aponta pro
+# manifesto do repo. O doctor invoca o specialist como subprocesso e não
+# exporta PRODUCTS_FILE, então em produção o default sempre vale.
+PRODUCTS_FILE="${PRODUCTS_FILE:-${REPO_ROOT}/scripts/data/products.json}"
 ENV_FILE="${COMPOSE_DIR:-$(pwd)}/.env"
 
 # Limiares de recursos: a fonte da verdade é o manifesto products.json — NÃO há
-# valores hardcoded neste script (issue #112). Lidos POR PRODUTO em
-# .products.<produto>.resources.* (VMs de produtos diferentes têm specs
-# diferentes — ex.: VMs com 7–8 GB de RAM) e, quando o produto não
-# declara um limiar, cai no fallback GLOBAL .defaults.resources.*. São lidos
-# após o parse de args (dependem de --product). Semântica: min_ram_mb = piso
-# bloqueante; recommended_ram_mb = alvo (entre piso e recomendado => aviso).
+# valores hardcoded como configuração (issue #112). Lidos do GLOBAL
+# .defaults.resources.* e, QUANDO há produto resolvido, sobrepostos pelo
+# .products.<produto>.resources.* (VMs de produtos diferentes podem crescer
+# independentemente). São lidos após o parse de args (--product é best-effort).
+# Semântica: min_ram_mb = piso bloqueante; recommended_ram_mb = alvo (entre piso
+# e recomendado => aviso).
 COMPOSE_DIR_PROBE="${COMPOSE_DIR:-$(pwd)}"
 
 usage() {
     cat <<EOF
 Uso: bash $(basename "$0") [--product NAME] [--quiet | --json] [--help]
 
-Verifica vCPUs, RAM e disco livre conforme os limiares do produto em
-scripts/data/products.json (.resources, fallback .defaults.resources).
-Requer produto: --product <rpa|dashboard|full> (ou SISCAN_PRODUCT / .env).
+Verifica vCPUs, RAM e disco livre conforme os limiares em
+scripts/data/products.json (.defaults.resources, com override por produto em
+.products.<p>.resources). PRODUCT-AGNOSTIC: roda sem --product; quando um
+produto é resolvido e declara .resources, ele sobrepõe os defaults.
 
 Exit code: 0 = OK · 1 = abaixo do mínimo · 2 = uso inválido
 EOF
@@ -58,26 +68,38 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-# Limiares lidos do manifesto products.json (fonte única — sem hardcode):
-# POR PRODUTO em .products.<p>.resources, com fallback GLOBAL em
-# .defaults.resources. Exige produto resolvido; falha só se NEM o produto NEM
-# o defaults declararem o limiar.
+# Resolver produto é BEST-EFFORT — check-resources é product-agnostic (mede
+# CPU/RAM/disco, que não dependem de produto). Sem produto resolvível, usa
+# .defaults.resources. NUNCA aborta por produto ausente (issues #112; F1/F2).
 resolve_product
-[ -n "${SISCAN_PRODUCT:-}" ] || fail "SISCAN_PRODUCT não definido (sem --product, sem env var, sem entrada em $ENV_FILE) — passe --product ou rode check-env"
-product_validate
 
-# _resource KEY → .products.<SISCAN_PRODUCT>.resources.KEY (fallback .defaults.resources.KEY)
+# _resource KEY → override do produto (.products.<p>.resources.KEY) se houver
+# produto resolvido, senão GLOBAL .defaults.resources.KEY. // empty preserva 0.
 _resource() {
-    jq -r ".products.\"$SISCAN_PRODUCT\".resources.$1 // .defaults.resources.$1 // empty" "$PRODUCTS_FILE" 2>/dev/null
+    local key="$1"
+    if [ -n "${SISCAN_PRODUCT:-}" ]; then
+        jq -r ".products.\"$SISCAN_PRODUCT\".resources.$key // .defaults.resources.$key // empty" "$PRODUCTS_FILE" 2>/dev/null
+    else
+        jq -r ".defaults.resources.$key // empty" "$PRODUCTS_FILE" 2>/dev/null
+    fi
 }
-MIN_VCPUS=$(_resource min_vcpus)
-MIN_RAM_MB=$(_resource min_ram_mb)
-RECOMMENDED_RAM_MB=$(_resource recommended_ram_mb)
-MIN_DISK_GB=$(_resource min_disk_gb)
-for _pair in "MIN_VCPUS:min_vcpus" "MIN_RAM_MB:min_ram_mb" "RECOMMENDED_RAM_MB:recommended_ram_mb" "MIN_DISK_GB:min_disk_gb"; do
-    _name="${_pair%%:*}"; _key="${_pair##*:}"
-    [ -n "${!_name}" ] || fail "resources.${_key} ausente em .products.$SISCAN_PRODUCT.resources e em .defaults.resources (products.json) — issue #112"
-done
+MIN_VCPUS=""
+MIN_RAM_MB=""
+RECOMMENDED_RAM_MB=""
+MIN_DISK_GB=""
+if command -v jq >/dev/null 2>&1 && [ -f "$PRODUCTS_FILE" ]; then
+    MIN_VCPUS=$(_resource min_vcpus)
+    MIN_RAM_MB=$(_resource min_ram_mb)
+    RECOMMENDED_RAM_MB=$(_resource recommended_ram_mb)
+    MIN_DISK_GB=$(_resource min_disk_gb)
+fi
+# Fallback de bootstrap (jq ausente / manifesto ilegível) — modo degradado, não
+# é a fonte da verdade; mantém os valores em paridade com .defaults.resources do
+# manifesto. Mesmo padrão de check-deps/check-db (F2/F6): degrada, não aborta.
+: "${MIN_VCPUS:=4}"
+: "${MIN_RAM_MB:=7168}"
+: "${RECOMMENDED_RAM_MB:=8192}"
+: "${MIN_DISK_GB:=20}"
 min_ram_gb=$(awk -v m="$MIN_RAM_MB" 'BEGIN{printf "%.0f", m/1024}')
 rec_ram_gb=$(awk -v m="$RECOMMENDED_RAM_MB" 'BEGIN{printf "%.0f", m/1024}')
 

--- a/scripts/deploy_server/check-resources.sh
+++ b/scripts/deploy_server/check-resources.sh
@@ -27,12 +27,13 @@ source "$SCRIPT_DIR/_common.sh"
 PRODUCTS_FILE="${REPO_ROOT}/scripts/data/products.json"
 ENV_FILE="${COMPOSE_DIR:-$(pwd)}/.env"
 
-# Limiares de recursos: a ÚNICA fonte da verdade é o manifesto products.json
-# (.products.<produto>.resources.*) — NÃO há valores hardcoded neste script
-# (issue #112). São lidos após o parse de args (dependem de --product), pois
-# VMs de produtos diferentes têm specs diferentes (ex.: VM do dashboard no
-# ICI = 7,7 GB). Semântica: min_ram_mb = piso bloqueante; recommended_ram_mb =
-# alvo (entre piso e recomendado => aviso não-bloqueante).
+# Limiares de recursos: a fonte da verdade é o manifesto products.json — NÃO há
+# valores hardcoded neste script (issue #112). Lidos POR PRODUTO em
+# .products.<produto>.resources.* (VMs de produtos diferentes têm specs
+# diferentes — ex.: VMs com 7–8 GB de RAM) e, quando o produto não
+# declara um limiar, cai no fallback GLOBAL .defaults.resources.*. São lidos
+# após o parse de args (dependem de --product). Semântica: min_ram_mb = piso
+# bloqueante; recommended_ram_mb = alvo (entre piso e recomendado => aviso).
 COMPOSE_DIR_PROBE="${COMPOSE_DIR:-$(pwd)}"
 
 usage() {
@@ -58,15 +59,16 @@ while [ $# -gt 0 ]; do
 done
 
 # Limiares lidos do manifesto products.json (fonte única — sem hardcode):
-# DEFINIDOS POR PRODUTO em .products.<p>.resources. Exige produto resolvido;
-# falha se o bloco resources do produto não declarar o limiar.
+# POR PRODUTO em .products.<p>.resources, com fallback GLOBAL em
+# .defaults.resources. Exige produto resolvido; falha só se NEM o produto NEM
+# o defaults declararem o limiar.
 resolve_product
 [ -n "${SISCAN_PRODUCT:-}" ] || fail "SISCAN_PRODUCT não definido (sem --product, sem env var, sem entrada em $ENV_FILE) — passe --product ou rode check-env"
 product_validate
 
-# _resource KEY → .products.<SISCAN_PRODUCT>.resources.KEY
+# _resource KEY → .products.<SISCAN_PRODUCT>.resources.KEY (fallback .defaults.resources.KEY)
 _resource() {
-    jq -r ".products.\"$SISCAN_PRODUCT\".resources.$1 // empty" "$PRODUCTS_FILE" 2>/dev/null
+    jq -r ".products.\"$SISCAN_PRODUCT\".resources.$1 // .defaults.resources.$1 // empty" "$PRODUCTS_FILE" 2>/dev/null
 }
 MIN_VCPUS=$(_resource min_vcpus)
 MIN_RAM_MB=$(_resource min_ram_mb)
@@ -74,7 +76,7 @@ RECOMMENDED_RAM_MB=$(_resource recommended_ram_mb)
 MIN_DISK_GB=$(_resource min_disk_gb)
 for _pair in "MIN_VCPUS:min_vcpus" "MIN_RAM_MB:min_ram_mb" "RECOMMENDED_RAM_MB:recommended_ram_mb" "MIN_DISK_GB:min_disk_gb"; do
     _name="${_pair%%:*}"; _key="${_pair##*:}"
-    [ -n "${!_name}" ] || fail "resources.${_key} ausente em .products.$SISCAN_PRODUCT.resources (products.json) — issue #112"
+    [ -n "${!_name}" ] || fail "resources.${_key} ausente em .products.$SISCAN_PRODUCT.resources e em .defaults.resources (products.json) — issue #112"
 done
 min_ram_gb=$(awk -v m="$MIN_RAM_MB" 'BEGIN{printf "%.0f", m/1024}')
 rec_ram_gb=$(awk -v m="$RECOMMENDED_RAM_MB" 'BEGIN{printf "%.0f", m/1024}')
@@ -97,7 +99,7 @@ fi
 # ────────────────────────────────────────────────────────────────────────────
 # RAM
 # ────────────────────────────────────────────────────────────────────────────
-print_category_header "$CAT_RAM" "products.json: recomendado ≥ ${rec_ram_gb} GB; piso bloqueante ${min_ram_gb} GB. Entre o piso e o recomendado é aviso (não bloqueia — ex.: VM do dashboard no ICI = 7,7 GB)."
+print_category_header "$CAT_RAM" "products.json: recomendado ≥ ${rec_ram_gb} GB; piso bloqueante ${min_ram_gb} GB. Entre o piso e o recomendado é aviso (não bloqueia — ex.: VMs com 7–8 GB de RAM)."
 ram_mb=$(free -m 2>/dev/null | awk '/^Mem:/ {print $2}')
 ram_mb=${ram_mb:-0}
 ram_gb=$(awk -v m="$ram_mb" 'BEGIN{printf "%.1f", m/1024}')

--- a/scripts/deploy_server/check-resources.sh
+++ b/scripts/deploy_server/check-resources.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # -------------------------------------------
 # Specialist: check-resources
-# Summary: CPU (>=4), RAM (>=8GB), disco livre (>=20GB) conforme DEPLOY_SERVER.md
+# Summary: vCPUs, RAM e disco livre — limiares POR PRODUTO em products.json
 # -------------------------------------------
-# Verifica que a VM atende aos requisitos mínimos de capacidade declarados na
-# tabela de pré-requisitos do DEPLOY_SERVER.md:
-#   - vCPUs >= 4
-#   - RAM >= 8 GB
-#   - Disco livre em $COMPOSE_DIR >= 20 GB
+# Verifica que a VM atende aos requisitos de capacidade declarados no manifesto
+# scripts/data/products.json (.products.<p>.resources, com fallback ao mínimo
+# aceitável GLOBAL .defaults.resources): min_vcpus, min_ram_mb (piso),
+# recommended_ram_mb (alvo; entre piso e recomendado = aviso) e min_disk_gb.
+# NÃO há limiar hardcoded aqui.
 #
 # Em VMs com menos recursos a stack até sobe, mas:
 #   - migrate + app + scheduler + redis disputam CPU em pull/up;
@@ -24,23 +24,24 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # shellcheck source=./_common.sh
 source "$SCRIPT_DIR/_common.sh"
 
-# Limites do DEPLOY_SERVER.md (tabela de pré-requisitos)
-MIN_VCPUS=4
-MIN_RAM_MB=$((8 * 1024))   # 8 GB (recomendado)
-# Piso de RAM (bloqueante). Entre WARN_RAM_MB e MIN_RAM_MB é apenas AVISO
-# (não-bloqueante): a VM contratada do ICI (VMPRDAPP-RPADASHBOARD) tem 7,7 GB
-# (Anexo G); reprovar o deploy por estar ~0,3 GB abaixo de 8 GB era
-# mis-calibração — bloqueava todo deploy nessa VM.
-WARN_RAM_MB=$((7 * 1024))  # 7 GB
-MIN_DISK_GB=20
+PRODUCTS_FILE="${REPO_ROOT}/scripts/data/products.json"
+ENV_FILE="${COMPOSE_DIR:-$(pwd)}/.env"
+
+# Limiares de recursos: a ÚNICA fonte da verdade é o manifesto products.json
+# (.products.<produto>.resources.*) — NÃO há valores hardcoded neste script
+# (issue #112). São lidos após o parse de args (dependem de --product), pois
+# VMs de produtos diferentes têm specs diferentes (ex.: VM do dashboard no
+# ICI = 7,7 GB). Semântica: min_ram_mb = piso bloqueante; recommended_ram_mb =
+# alvo (entre piso e recomendado => aviso não-bloqueante).
 COMPOSE_DIR_PROBE="${COMPOSE_DIR:-$(pwd)}"
 
 usage() {
     cat <<EOF
-Uso: bash $(basename "$0") [--quiet | --json] [--help]
+Uso: bash $(basename "$0") [--product NAME] [--quiet | --json] [--help]
 
-Verifica vCPUs, RAM e disco livre conforme DEPLOY_SERVER.md
-(mínimos: 4 vCPU, 8 GB RAM, 20 GB livres em \$COMPOSE_DIR).
+Verifica vCPUs, RAM e disco livre conforme os limiares do produto em
+scripts/data/products.json (.resources, fallback .defaults.resources).
+Requer produto: --product <rpa|dashboard|full> (ou SISCAN_PRODUCT / .env).
 
 Exit code: 0 = OK · 1 = abaixo do mínimo · 2 = uso inválido
 EOF
@@ -55,6 +56,28 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+# Limiares lidos do manifesto products.json (fonte única — sem hardcode):
+# DEFINIDOS POR PRODUTO em .products.<p>.resources. Exige produto resolvido;
+# falha se o bloco resources do produto não declarar o limiar.
+resolve_product
+[ -n "${SISCAN_PRODUCT:-}" ] || fail "SISCAN_PRODUCT não definido (sem --product, sem env var, sem entrada em $ENV_FILE) — passe --product ou rode check-env"
+product_validate
+
+# _resource KEY → .products.<SISCAN_PRODUCT>.resources.KEY
+_resource() {
+    jq -r ".products.\"$SISCAN_PRODUCT\".resources.$1 // empty" "$PRODUCTS_FILE" 2>/dev/null
+}
+MIN_VCPUS=$(_resource min_vcpus)
+MIN_RAM_MB=$(_resource min_ram_mb)
+RECOMMENDED_RAM_MB=$(_resource recommended_ram_mb)
+MIN_DISK_GB=$(_resource min_disk_gb)
+for _pair in "MIN_VCPUS:min_vcpus" "MIN_RAM_MB:min_ram_mb" "RECOMMENDED_RAM_MB:recommended_ram_mb" "MIN_DISK_GB:min_disk_gb"; do
+    _name="${_pair%%:*}"; _key="${_pair##*:}"
+    [ -n "${!_name}" ] || fail "resources.${_key} ausente em .products.$SISCAN_PRODUCT.resources (products.json) — issue #112"
+done
+min_ram_gb=$(awk -v m="$MIN_RAM_MB" 'BEGIN{printf "%.0f", m/1024}')
+rec_ram_gb=$(awk -v m="$RECOMMENDED_RAM_MB" 'BEGIN{printf "%.0f", m/1024}')
 
 CAT_CPU="vCPUs"
 CAT_RAM="Memória RAM"
@@ -74,17 +97,17 @@ fi
 # ────────────────────────────────────────────────────────────────────────────
 # RAM
 # ────────────────────────────────────────────────────────────────────────────
-print_category_header "$CAT_RAM" "DEPLOY_SERVER.md recomenda ≥ 8 GB. Entre 7 e 8 GB é aviso (não bloqueia — VM contratada do ICI = 7,7 GB); abaixo de 7 GB bloqueia."
+print_category_header "$CAT_RAM" "products.json: recomendado ≥ ${rec_ram_gb} GB; piso bloqueante ${min_ram_gb} GB. Entre o piso e o recomendado é aviso (não bloqueia — ex.: VM do dashboard no ICI = 7,7 GB)."
 ram_mb=$(free -m 2>/dev/null | awk '/^Mem:/ {print $2}')
 ram_mb=${ram_mb:-0}
 ram_gb=$(awk -v m="$ram_mb" 'BEGIN{printf "%.1f", m/1024}')
-if [ "$ram_mb" -ge "$MIN_RAM_MB" ] 2>/dev/null; then
-    add_ok "$CAT_RAM" ram 0 "$(hostname)" "${ram_gb} GB (>= 8 GB)"
-elif [ "$ram_mb" -ge "$WARN_RAM_MB" ] 2>/dev/null; then
+if [ "$ram_mb" -ge "$RECOMMENDED_RAM_MB" ] 2>/dev/null; then
+    add_ok "$CAT_RAM" ram 0 "$(hostname)" "${ram_gb} GB (>= ${rec_ram_gb} GB recomendado)"
+elif [ "$ram_mb" -ge "$MIN_RAM_MB" ] 2>/dev/null; then
     # Aviso NÃO-bloqueante (convenção do repo: add_ok com "(warn)" no detalhe).
-    add_ok "$CAT_RAM" ram 0 "$(hostname)" "${ram_gb} GB (warn) — abaixo do recomendado 8 GB, mas dentro da spec da VM; monitorar OOM sob carga"
+    add_ok "$CAT_RAM" ram 0 "$(hostname)" "${ram_gb} GB (warn) — abaixo do recomendado ${rec_ram_gb} GB, acima do piso ${min_ram_gb} GB; monitorar OOM sob carga"
 else
-    add_fail "$CAT_RAM" ram 0 "$(hostname)" "${ram_gb} GB (abaixo do piso de 7 GB; recomendado >= 8 GB) — risco de OOM kills"
+    add_fail "$CAT_RAM" ram 0 "$(hostname)" "${ram_gb} GB (abaixo do piso de ${min_ram_gb} GB; recomendado >= ${rec_ram_gb} GB) — risco de OOM kills"
 fi
 
 # ────────────────────────────────────────────────────────────────────────────

--- a/scripts/deploy_server/check-resources.sh
+++ b/scripts/deploy_server/check-resources.sh
@@ -26,7 +26,12 @@ source "$SCRIPT_DIR/_common.sh"
 
 # Limites do DEPLOY_SERVER.md (tabela de pré-requisitos)
 MIN_VCPUS=4
-MIN_RAM_MB=$((8 * 1024))   # 8 GB
+MIN_RAM_MB=$((8 * 1024))   # 8 GB (recomendado)
+# Piso de RAM (bloqueante). Entre WARN_RAM_MB e MIN_RAM_MB é apenas AVISO
+# (não-bloqueante): a VM contratada do ICI (VMPRDAPP-RPADASHBOARD) tem 7,7 GB
+# (Anexo G); reprovar o deploy por estar ~0,3 GB abaixo de 8 GB era
+# mis-calibração — bloqueava todo deploy nessa VM.
+WARN_RAM_MB=$((7 * 1024))  # 7 GB
 MIN_DISK_GB=20
 COMPOSE_DIR_PROBE="${COMPOSE_DIR:-$(pwd)}"
 
@@ -69,14 +74,17 @@ fi
 # ────────────────────────────────────────────────────────────────────────────
 # RAM
 # ────────────────────────────────────────────────────────────────────────────
-print_category_header "$CAT_RAM" "DEPLOY_SERVER.md exige ≥ 8 GB — Python heap, cache Redis (dashboard) e Playwright (RPA) somam várias centenas de MB cada."
+print_category_header "$CAT_RAM" "DEPLOY_SERVER.md recomenda ≥ 8 GB. Entre 7 e 8 GB é aviso (não bloqueia — VM contratada do ICI = 7,7 GB); abaixo de 7 GB bloqueia."
 ram_mb=$(free -m 2>/dev/null | awk '/^Mem:/ {print $2}')
 ram_mb=${ram_mb:-0}
 ram_gb=$(awk -v m="$ram_mb" 'BEGIN{printf "%.1f", m/1024}')
 if [ "$ram_mb" -ge "$MIN_RAM_MB" ] 2>/dev/null; then
     add_ok "$CAT_RAM" ram 0 "$(hostname)" "${ram_gb} GB (>= 8 GB)"
+elif [ "$ram_mb" -ge "$WARN_RAM_MB" ] 2>/dev/null; then
+    # Aviso NÃO-bloqueante (convenção do repo: add_ok com "(warn)" no detalhe).
+    add_ok "$CAT_RAM" ram 0 "$(hostname)" "${ram_gb} GB (warn) — abaixo do recomendado 8 GB, mas dentro da spec da VM; monitorar OOM sob carga"
 else
-    add_fail "$CAT_RAM" ram 0 "$(hostname)" "${ram_gb} GB (esperado >= 8 GB) — pode causar OOM kills sob carga"
+    add_fail "$CAT_RAM" ram 0 "$(hostname)" "${ram_gb} GB (abaixo do piso de 7 GB; recomendado >= 8 GB) — risco de OOM kills"
 fi
 
 # ────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_check_db_pg_version.bats
+++ b/tests/unit/test_check_db_pg_version.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# Testes para scripts/deploy_server/check-db.sh — camada de versão do PostgreSQL
+# (PR #111 — limiares de host em products.json; issue #113; F4/F9).
+#
+# Cobertura:
+#   - PG >= alvo (16) => ok citando o alvo.
+#   - PG entre piso (14) e alvo (16) => ok, mensagem cita ALVO e PISO (F9).
+#   - PG abaixo do piso (13) => FAIL.
+#
+# Estratégia: stub de `timeout` (TCP sempre "aberto") e `psql` (responde
+# SHOW server_version). pg_isready ausente do PATH (skip controlado).
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+setup() {
+    PROJECT_DIR="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    SPECIALIST="${PROJECT_DIR}/scripts/deploy_server/check-db.sh"
+    STUB_DIR="$(mktemp -d)"
+    WORK_DIR="$(mktemp -d)"
+    for b in bash awk hostname tr tail head cut grep sed sort dirname pwd cat env mktemp jq; do
+        real="$(command -v "$b" 2>/dev/null)" && ln -sf "$real" "${STUB_DIR}/${b}"
+    done
+    # timeout stub: ignora o comando e retorna sucesso (TCP "aberto").
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'exit 0\n'
+    } > "${STUB_DIR}/timeout"
+    chmod +x "${STUB_DIR}/timeout"
+    # .env mínimo apontando pro banco principal.
+    cat > "${WORK_DIR}/.env" <<EOF
+SISCAN_PRODUCT=rpa
+DATABASE_HOST=db.exemplo.local
+DATABASE_PORT=5432
+DATABASE_USER=app
+DATABASE_NAME=appdb
+DATABASE_PASSWORD=segredo
+EOF
+}
+
+teardown() {
+    rm -rf "$STUB_DIR" "$WORK_DIR"
+}
+
+# _stub_psql VERSION — `psql ... -tAc "SHOW server_version"` imprime VERSION.
+_stub_psql() {
+    rm -f "${STUB_DIR}/psql"
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'echo "%s"\n' "$1"
+    } > "${STUB_DIR}/psql"
+    chmod +x "${STUB_DIR}/psql"
+}
+
+_run_db() {
+    run env PATH="${STUB_DIR}" COMPOSE_DIR="${WORK_DIR}" \
+        bash "$SPECIALIST" --env-file "${WORK_DIR}/.env" --product rpa --json
+}
+
+@test "PG >= alvo (16) => ok citando o alvo" {
+    _stub_psql "16.4"
+    _run_db
+    run bash -c "env PATH='${STUB_DIR}' COMPOSE_DIR='${WORK_DIR}' bash '$SPECIALIST' --env-file '${WORK_DIR}/.env' --product rpa --json | jq -r '.checks[] | select(.protocol==\"pg\") | .detail' | grep PostgreSQL"
+    assert_output --partial 'PostgreSQL 16.4'
+    assert_output --partial '>= 16'
+}
+
+@test "F9: PG entre piso (14) e alvo (16) cita ALVO e PISO" {
+    _stub_psql "15.6"
+    run bash -c "env PATH='${STUB_DIR}' COMPOSE_DIR='${WORK_DIR}' bash '$SPECIALIST' --env-file '${WORK_DIR}/.env' --product rpa --json | jq -r '.checks[] | select(.protocol==\"pg\") | .detail' | grep PostgreSQL"
+    assert_output --partial 'anterior ao alvo 16'
+    assert_output --partial 'piso 14'
+}
+
+@test "PG abaixo do piso (13) => FAIL" {
+    _stub_psql "13.10"
+    run bash -c "env PATH='${STUB_DIR}' COMPOSE_DIR='${WORK_DIR}' bash '$SPECIALIST' --env-file '${WORK_DIR}/.env' --product rpa --json | jq -r '.checks[] | select(.protocol==\"pg\" and .status==\"fail\") | .detail'"
+    assert_output --partial 'muito antigo'
+    assert_output --partial '>= 16'
+}

--- a/tests/unit/test_check_deps_versions.bats
+++ b/tests/unit/test_check_deps_versions.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+# Testes para o specialist scripts/deploy_server/check-deps.sh
+# (PR #111 — requisitos de host em products.json + camadas de versão; issue #113; F4).
+#
+# Cobertura:
+#   - Docker em camadas: >= recomendado (ok), entre piso e alvo (warn), abaixo
+#     do piso (warn mais forte) — versão é advisory, nunca FAIL.
+#   - Compose comparado via sort -V: >= piso ok; abaixo = warn; sufixo -desktop.1
+#     e o caso 2.5 < 2.37 tratados corretamente.
+#   - Drift-guard: binário exigido no manifesto sem rotina de verificação => FAIL.
+#   - Fallback de bootstrap: sem jq, os limiares caem no default e o specialist
+#     ainda roda (degrada, não aborta).
+#
+# Estratégia: stubs de docker (engine + plugin compose) num PATH controlado.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+setup() {
+    PROJECT_DIR="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    SPECIALIST="${PROJECT_DIR}/scripts/deploy_server/check-deps.sh"
+    STUB_DIR="$(mktemp -d)"
+    WORK_DIR="$(mktemp -d)"
+    for b in bash awk hostname tr tail head cut grep sed sort dirname pwd cat env mktemp jq curl openssl sudo timeout getent git; do
+        real="$(command -v "$b" 2>/dev/null)" && ln -sf "$real" "${STUB_DIR}/${b}"
+    done
+}
+
+teardown() {
+    rm -rf "$STUB_DIR" "$WORK_DIR"
+}
+
+# _stub_docker SERVER_VERSION COMPOSE_VERSION — instala um stub de `docker`
+# que responde a `docker version --format '{{.Server.Version}}'` e a
+# `docker compose version --short`.
+_stub_docker() {
+    local server_ver="$1" compose_ver="$2"
+    rm -f "${STUB_DIR}/docker"
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'if [ "$1" = "version" ]; then echo "%s"; exit 0; fi\n' "$server_ver"
+        printf 'if [ "$1" = "compose" ] && [ "$2" = "version" ]; then echo "%s"; exit 0; fi\n' "$compose_ver"
+        printf 'exit 0\n'
+    } > "${STUB_DIR}/docker"
+    chmod +x "${STUB_DIR}/docker"
+}
+
+_run_deps() {
+    run env PATH="${STUB_DIR}" COMPOSE_DIR="${WORK_DIR}" bash "$SPECIALIST" --json
+}
+
+# ── Docker engine em camadas (advisory, nunca FAIL pela versão) ─────────────
+
+@test "Docker >= recomendado (28) => ok sem warn de versão" {
+    _stub_docker "28.1.0" "2.40.0"
+    _run_deps
+    assert_output --partial '"target": "docker"'
+    assert_output --partial '28.1.0'
+    # A linha do docker engine não deve ter warn de versão.
+    run bash -c "env PATH='${STUB_DIR}' COMPOSE_DIR='${WORK_DIR}' bash '$SPECIALIST' --json | jq -r '.checks[] | select(.target==\"docker\") | .detail'"
+    refute_output --partial '(warn)'
+}
+
+@test "Docker entre piso (24) e alvo (28) => ok com (warn) citando o piso" {
+    _stub_docker "25.0.3" "2.40.0"
+    run bash -c "env PATH='${STUB_DIR}' COMPOSE_DIR='${WORK_DIR}' bash '$SPECIALIST' --json | jq -r '.checks[] | select(.target==\"docker\") | .detail'"
+    assert_output --partial '(warn)'
+    assert_output --partial '24'
+}
+
+@test "Docker abaixo do piso (23) => ok com (warn), nunca FAIL pela versão" {
+    _stub_docker "23.0.1" "2.40.0"
+    run bash -c "env PATH='${STUB_DIR}' COMPOSE_DIR='${WORK_DIR}' bash '$SPECIALIST' --json | jq -r '.checks[] | select(.target==\"docker\") | [.status, .detail] | @tsv'"
+    assert_output --partial 'ok'
+    assert_output --partial '(warn)'
+}
+
+# ── Compose via sort -V ─────────────────────────────────────────────────────
+
+@test "Compose >= piso (2.37) => ok" {
+    _stub_docker "28.0.0" "2.40.1"
+    run bash -c "env PATH='${STUB_DIR}' COMPOSE_DIR='${WORK_DIR}' bash '$SPECIALIST' --json | jq -r '.checks[] | select(.target==\"docker compose\") | .detail'"
+    assert_output --partial '>= 2.37'
+}
+
+@test "Compose 2.5 é MENOR que 2.37 (sort -V numérico) => warn" {
+    _stub_docker "28.0.0" "2.5.0"
+    run bash -c "env PATH='${STUB_DIR}' COMPOSE_DIR='${WORK_DIR}' bash '$SPECIALIST' --json | jq -r '.checks[] | select(.target==\"docker compose\") | .detail'"
+    assert_output --partial '(warn)'
+}
+
+@test "Compose com sufixo -desktop.1 acima do piso => ok" {
+    _stub_docker "28.0.0" "2.38.1-desktop.1"
+    run bash -c "env PATH='${STUB_DIR}' COMPOSE_DIR='${WORK_DIR}' bash '$SPECIALIST' --json | jq -r '.checks[] | select(.target==\"docker compose\") | .detail'"
+    assert_output --partial '>= 2.37'
+}
+
+# ── Drift-guard: binário no manifesto sem rotina de verificação => FAIL ──────
+
+@test "drift-guard: binário fantasma no manifesto vira FAIL" {
+    _stub_docker "28.0.0" "2.40.0"
+    # Manifesto com um binário inexistente em _bin_category (drift).
+    local manifest="${WORK_DIR}/products.json"
+    cat > "$manifest" <<'EOF'
+{
+  "defaults": {
+    "host_requirements": {
+      "min_docker_major": 24, "recommended_docker_major": 28,
+      "min_compose_version": "2.37",
+      "ubuntu_target_major": 24, "ubuntu_supported_major": 22,
+      "required_binaries": ["curl", "binario-fantasma"]
+    }
+  }
+}
+EOF
+    run env PATH="${STUB_DIR}" COMPOSE_DIR="${WORK_DIR}" PRODUCTS_FILE="$manifest" \
+        bash "$SPECIALIST" --json
+    assert_output --partial 'binario-fantasma'
+    assert_output --partial 'drift'
+    assert_output --partial '"status": "fail"'
+}
+
+# ── Fallback de bootstrap (sem jq) ──────────────────────────────────────────
+
+@test "sem jq: usa fallback de bootstrap e ainda avalia o docker" {
+    _stub_docker "28.0.0" "2.40.0"
+    rm -f "${STUB_DIR}/jq"
+    run env PATH="${STUB_DIR}" COMPOSE_DIR="${WORK_DIR}" bash "$SPECIALIST" --json
+    # jq ausente é reportado como FAIL (binário de rede), mas o specialist
+    # roda até o fim e avalia o docker com os limiares de fallback.
+    assert_output --partial '"target": "docker"'
+    assert_output --partial '28.0.0'
+}

--- a/tests/unit/test_check_resources.bats
+++ b/tests/unit/test_check_resources.bats
@@ -1,0 +1,197 @@
+#!/usr/bin/env bats
+# Testes para o specialist scripts/deploy_server/check-resources.sh
+# (PR #111 — RAM em camadas + limiares em products.json, issue #112; F1/F2/F4).
+#
+# Cobertura:
+#   - Camada de RAM: >= recomendado (ok), entre piso e recomendado (ok + warn),
+#     abaixo do piso (FAIL).
+#   - vCPUs e disco abaixo do mínimo => FAIL.
+#   - F1: rodar SEM produto (env -u SISCAN_PRODUCT, sem --product) NÃO aborta
+#     (exit 0/1 conforme recursos, nunca exit 2 por produto ausente).
+#   - F2: rodar SEM jq no PATH degrada via fallback de bootstrap (não aborta).
+#   - Override por produto em .products.<p>.resources sobrepõe .defaults.
+#
+# Estratégia: stubs de free/nproc/df num diretório à frente do PATH, com
+# coreutils reais linkados, para fixar as fronteiras das camadas sem depender
+# do hardware real do runner.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+
+setup() {
+    PROJECT_DIR="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    SPECIALIST="${PROJECT_DIR}/scripts/deploy_server/check-resources.sh"
+    STUB_DIR="$(mktemp -d)"
+    WORK_DIR="$(mktemp -d)"   # COMPOSE_DIR existente, p/ o probe de disco
+    # Linka os utilitários reais que o script usa, exceto os que vamos stubar.
+    for b in bash awk hostname tr tail head cut grep sed sort dirname pwd cat env nproc free df mktemp; do
+        real="$(command -v "$b" 2>/dev/null)" && ln -sf "$real" "${STUB_DIR}/${b}"
+    done
+}
+
+teardown() {
+    rm -rf "$STUB_DIR" "$WORK_DIR"
+}
+
+# _stub_free MB  — instala um stub de `free` que reporta MB de RAM total.
+# rm -f primeiro: os links de setup() apontam pro binário real; escrever via
+# `>` no symlink atingiria o alvo (Permission denied). Removemos o link antes.
+_stub_free() {
+    rm -f "${STUB_DIR}/free"
+    cat > "${STUB_DIR}/free" <<EOF
+#!/usr/bin/env bash
+echo "              total        used        free"
+echo "Mem:           $1         100         100"
+EOF
+    chmod +x "${STUB_DIR}/free"
+}
+
+# _stub_nproc N
+_stub_nproc() {
+    rm -f "${STUB_DIR}/nproc"
+    printf '#!/usr/bin/env bash\necho %s\n' "$1" > "${STUB_DIR}/nproc"
+    chmod +x "${STUB_DIR}/nproc"
+}
+
+# _stub_df GB  — `df -BG --output=avail PATH` imprime header + "<GB>G".
+_stub_df() {
+    rm -f "${STUB_DIR}/df"
+    cat > "${STUB_DIR}/df" <<EOF
+#!/usr/bin/env bash
+echo "Avail"
+echo "${1}G"
+EOF
+    chmod +x "${STUB_DIR}/df"
+}
+
+# _run_specialist [extra args...] — roda o specialist com stubs no PATH,
+# COMPOSE_DIR válido e SEM SISCAN_PRODUCT herdado (testa o caminho agnóstico).
+_run_specialist() {
+    run env -u SISCAN_PRODUCT PATH="${STUB_DIR}" COMPOSE_DIR="${WORK_DIR}" \
+        bash "$SPECIALIST" --json "$@"
+}
+
+# ── Camadas de RAM ──────────────────────────────────────────────────────────
+
+@test "RAM >= recomendado (8 GB) => ok sem warn" {
+    _stub_nproc 4; _stub_free 8192; _stub_df 50
+    _run_specialist
+    assert_success
+    assert_output --partial '"status": "ok"'
+    refute_output --partial '(warn)'
+}
+
+@test "RAM entre piso (7 GB) e recomendado (8 GB) => ok COM (warn), não bloqueia" {
+    _stub_nproc 4; _stub_free 7500; _stub_df 50
+    _run_specialist
+    assert_success          # aviso não-bloqueante: exit 0
+    assert_output --partial '(warn)'
+    assert_output --partial '"fail": 0'   # nenhuma falha no sumário
+    refute_output --partial '"status": "fail"'
+}
+
+@test "RAM exatamente no piso (7168 MB) => ok COM (warn)" {
+    _stub_nproc 4; _stub_free 7168; _stub_df 50
+    _run_specialist
+    assert_success
+    assert_output --partial '(warn)'
+}
+
+@test "RAM abaixo do piso (6 GB) => FAIL (exit 1)" {
+    _stub_nproc 4; _stub_free 6144; _stub_df 50
+    _run_specialist
+    assert_failure
+    assert_output --partial '"status": "fail"'
+    assert_output --partial 'abaixo do piso'
+}
+
+# ── vCPUs e disco ───────────────────────────────────────────────────────────
+
+@test "vCPUs abaixo do mínimo (2 < 4) => FAIL" {
+    _stub_nproc 2; _stub_free 8192; _stub_df 50
+    _run_specialist
+    assert_failure
+    assert_output --partial 'vCPUs'
+    assert_output --partial '"status": "fail"'
+}
+
+@test "disco abaixo do mínimo (10 < 20 GB) => FAIL" {
+    _stub_nproc 4; _stub_free 8192; _stub_df 10
+    _run_specialist
+    assert_failure
+    assert_output --partial '"status": "fail"'
+}
+
+# ── F1: product-agnostic (não aborta sem produto) ───────────────────────────
+
+@test "F1: roda SEM --product e SEM SISCAN_PRODUCT — não aborta (exit != 2)" {
+    _stub_nproc 4; _stub_free 8192; _stub_df 50
+    _run_specialist
+    # O ponto do F1: não pode ser exit 2 (uso inválido por produto ausente).
+    assert_equal "$status" 0
+    refute_output --partial 'SISCAN_PRODUCT não definido'
+}
+
+@test "F1: recursos suficientes sem produto => exit 0" {
+    _stub_nproc 8; _stub_free 16384; _stub_df 100
+    _run_specialist
+    assert_success
+}
+
+# ── F2: degrada sem jq (fallback de bootstrap) ──────────────────────────────
+
+@test "F2: sem jq no PATH usa fallback de bootstrap e não aborta" {
+    _stub_nproc 4; _stub_free 8192; _stub_df 50
+    rm -f "${STUB_DIR}/jq" 2>/dev/null || true   # garante ausência de jq
+    # PATH só com o stub dir: jq não está presente.
+    run env -u SISCAN_PRODUCT PATH="${STUB_DIR}" COMPOSE_DIR="${WORK_DIR}" \
+        bash "$SPECIALIST" --json
+    assert_success
+    assert_output --partial '"status": "ok"'
+}
+
+@test "F2: sem jq, RAM abaixo do piso ainda FALHA (fallback 7168 ativo)" {
+    _stub_nproc 4; _stub_free 6000; _stub_df 50
+    rm -f "${STUB_DIR}/jq" 2>/dev/null || true
+    run env -u SISCAN_PRODUCT PATH="${STUB_DIR}" COMPOSE_DIR="${WORK_DIR}" \
+        bash "$SPECIALIST" --json
+    assert_failure
+    assert_output --partial 'abaixo do piso'
+}
+
+# ── Override por produto sobrepõe .defaults ─────────────────────────────────
+
+@test "override por produto: .products.<p>.resources sobrepõe .defaults" {
+    _stub_nproc 4; _stub_free 8192; _stub_df 50
+    # Manifesto temporário onde rpa exige 32 vCPUs (defaults = 4).
+    local manifest="${WORK_DIR}/products.json"
+    cat > "$manifest" <<'EOF'
+{
+  "defaults": { "resources": { "min_vcpus": 4, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 } },
+  "products": { "rpa": { "resources": { "min_vcpus": 32, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 } } }
+}
+EOF
+    ln -sf "$(command -v jq)" "${STUB_DIR}/jq"
+    run env -u SISCAN_PRODUCT PATH="${STUB_DIR}" COMPOSE_DIR="${WORK_DIR}" \
+        PRODUCTS_FILE="$manifest" bash "$SPECIALIST" --product rpa --json
+    # 4 vCPUs < 32 exigidos pelo override do produto => FAIL.
+    assert_failure
+    assert_output --partial '>= 32'
+}
+
+@test "sem produto usa .defaults (4 vCPUs) mesmo com override de produto no manifesto" {
+    _stub_nproc 4; _stub_free 8192; _stub_df 50
+    local manifest="${WORK_DIR}/products.json"
+    cat > "$manifest" <<'EOF'
+{
+  "defaults": { "resources": { "min_vcpus": 4, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 } },
+  "products": { "rpa": { "resources": { "min_vcpus": 32, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 } } }
+}
+EOF
+    ln -sf "$(command -v jq)" "${STUB_DIR}/jq"
+    run env -u SISCAN_PRODUCT PATH="${STUB_DIR}" COMPOSE_DIR="${WORK_DIR}" \
+        PRODUCTS_FILE="$manifest" bash "$SPECIALIST" --json
+    # Sem produto => defaults (4 vCPUs); 4 >= 4 => ok.
+    assert_success
+    assert_output --partial '>= 4'
+}


### PR DESCRIPTION
Move os limiares de capacidade e requisitos de host dos specialists do `siscan-server-doctor` para o manifesto declarativo `scripts/data/products.json`, eliminando hardcode. Cobre dois eixos: **recursos da VM por produto** (#112) e **requisitos de host globais alinhados à tabela de pré-requisitos do `DEPLOY_SERVER.md`** (#113).

## Contexto

O specialist `check-resources` reprovava (`add_fail`) **qualquer RAM < 8 GB**. Como o `siscan-server-doctor` faz `finalize_exit = exit 1` com **qualquer** `fail`, isso **abortava o `pre-deploy` do CD** do siscan-dashboard e deixava o `deploy` **skipped**. Uma das VMs de produção tem **7,7 GB de RAM** → o limiar fixo `≥ 8 GB` **reprovava todo deploy** nessa VM.

A investigação mostrou que `check-resources` era o **único specialist** ainda com limiares hardcoded e que `check-deps`/`check-db` carregavam requisitos de host hardcoded, **divergindo da tabela de pré-requisitos do `DEPLOY_SERVER.md`**. Este PR alinha tudo.

## Escopo #112 — recursos da VM por produto

- **`products.json`**: bloco `resources` por produto (`rpa`/`dashboard`/`full`) + fallback global `defaults.resources` + doc no `schema`:
  ```json
  "resources": { "min_vcpus": 4, "min_ram_mb": 7168, "recommended_ram_mb": 8192, "min_disk_gb": 20 }
  ```
- **`check-resources.sh`**: resolve o produto (`resolve_product`) e lê os limiares do manifesto — **sem hardcode** —, com fallback para `defaults.resources` quando o produto não declara um limiar. RAM em camadas: **≥ recomendado (8 GB)** ok; **entre piso e recomendado (7–8 GB)** aviso não-bloqueante; **< piso (7 GB)** fail. Cada produto tem sua própria VM e pode crescer independentemente.

## Escopo #113 — requisitos de host globais (tabela DEPLOY_SERVER.md)

Bloco global `defaults.host_requirements` no manifesto:
```json
"host_requirements": {
  "min_docker_major": 24,
  "recommended_docker_major": 28,
  "min_compose_version": "2.37",
  "min_postgres_major": 16,
  "supported_postgres_major": 14,
  "ubuntu_target_major": 24,
  "ubuntu_supported_major": 22,
  "required_binaries": ["curl", "jq", "openssl", "sudo", "timeout", "getent", "git"]
}
```

- **`check-deps.sh`** — lê do manifesto, sem hardcode:
  - **Docker Engine**: piso `24` + **recomendado `28+`** (entre piso e alvo → aviso).
  - **Docker Compose**: passa a **verificar a versão** (`≥ 2.37`) via `sort -V` — antes só checava presença do plugin.
  - **Ubuntu**: alvo `24` + piso suportado `22`.
  - **Binários**: lista do manifesto, com **drift-guard** (binário sem rotina de verificação → FAIL).
  - **Fallback de bootstrap**: sem `jq` (que o próprio check-deps detecta) o manifesto fica ilegível → fallback mínimo em paridade só pra não travar o diagnóstico.
- **`check-db.sh`** — **PostgreSQL `≥ 16`** (alvo) / `14` (piso funcional) agora lidos do manifesto via `SHOW server_version`, em vez de hardcoded. `TIMEOUT_SEC` e porta `5432` ficam no script, justificados (já configuráveis / convenção).
- **`check-docker.sh`** — `/var/run/docker.sock`, `daemon.json`, pool `172.17.0.0/16`: convenções fixas do Docker, mantidas com justificativa (não variam por produto).

## Cobertura da tabela de pré-requisitos (DEPLOY_SERVER.md)

| Requisito | Valor | Specialist | Fonte |
|---|---|---|---|
| Ubuntu | 24.04 LTS (alvo) | check-deps | manifesto |
| vCPUs / RAM | 4 / 8 GB | check-resources | manifesto (por produto) |
| Docker Engine | ≥ 24 (rec. 28+) | check-deps | manifesto |
| Docker Compose | ≥ 2.37 | check-deps | manifesto (verifica versão) |
| PostgreSQL | ≥ 16 | check-db | manifesto |
| deps git/jq/openssl/curl/sudo/timeout | — | check-deps | manifesto |

## Validação

- `jq` valida `products.json`; `bash -n` OK em todos os specialists.
- Suíte **bats unit completa passa** (237 OK, 0 falhas).
- Execução real do `check-deps` (human + `--json`): Docker 28.3.0 ok, Compose 2.38.1 `(>= 2.37)`.
- Testados: **drift-guard** (binário fantasma → FAIL), **fallback de bootstrap** (manifesto ausente → degrada, exit 0), **fallback `defaults.resources`**, **camadas de aviso** (Docker 24–27, Compose < 2.37) e comparação **`sort -V`**.
- Termos internos: `git grep` limpo; guarda LGPD do CI verde.

## Ação operacional após o merge

Re-sincronizar o assistente na VM: `siscan-server-setup.sh --product dashboard` (atualiza `siscan-server-doctor.sh`/specialists no `COMPOSE_DIR`), depois **re-disparar o CD** do dashboard. Enquanto a VM não for re-sincronizada, o workaround temporário do siscan-dashboard#607 (ignorar só a falha de RAM no pré-deploy) cobre a lacuna; esta é a correção **definitiva** no doctor.

Closes: #112
Closes: #113
Refs: Prisma-Consultoria/siscan-dashboard#597, Prisma-Consultoria/siscan-dashboard#607
